### PR TITLE
docs: document pre-1.0 breaking-change versioning exception

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,5 +73,6 @@ and `net10.0`.
 before it is made.** A breaking change is anything not backward-compatible for
 consumers — removing or renaming public members, changing public signatures, or
 altering observable behaviour. When a requested task would require one, stop and
-get explicit confirmation first; then bump the **Major** version per
-[CONTRIBUTING.md](CONTRIBUTING.md).
+get explicit confirmation first; then bump the version per
+[CONTRIBUTING.md](CONTRIBUTING.md) — while `MajorVersion` is `0`, do **not** bump
+Major unless explicitly told (see its "Pre-1.0 versioning" note).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,16 @@ Apply these rules when deciding what to bump:
 > A breaking change to the library must be confirmed with the human maintainer
 > before it is made. See [AGENTS.md](AGENTS.md).
 
+### Pre-1.0 versioning (temporary)
+
+While `MajorVersion` is `0` (pre-release), a breaking change does **not**
+increment the Major version. Keep Major at `0` and bump **Minor** instead
+(resetting `Revision` to `0`) — **unless the maintainer explicitly instructs a
+Major bump**. This overrides rule 2 above for as long as the project is pre-1.0.
+
+**Remove this entire subsection once the version reaches `1.0.0`**, after which
+the standard rule 2 (breaking → Major) applies.
+
 Whenever you bump the version, record the change in
 [CHANGELOG.md](CHANGELOG.md) under the `[Unreleased]` section.
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,8 @@
 		<Copyright>Copyright © 2023</Copyright>
 		<Description>The library for testable time management.</Description>
 
+		<!-- Pre-1.0 exception active: while MajorVersion is 0, breaking changes do NOT bump
+		     Major (see CONTRIBUTING.md "Pre-1.0 versioning"). Remove that note when raising to 1. -->
 		<MajorVersion>0</MajorVersion>
 		<MinorVersion>2</MinorVersion>
 		<Revision>0</Revision>


### PR DESCRIPTION
## Summary

Documents a **temporary pre-1.0 versioning policy**: while the library is pre-release (`MajorVersion = 0`), a breaking change does **not** bump the Major version unless the maintainer explicitly instructs it — bump **Minor** instead. The note is self-removing: it carries an explicit instruction to delete it once the version reaches `1.0.0`.

Documentation-only — no code change, no version bump, no package impact.

## Notable changes

- **`CONTRIBUTING.md`** — new `### Pre-1.0 versioning (temporary)` subsection under Versioning, overriding rule 2 (breaking → Major) for as long as the project is pre-1.0, with a remove-at-`1.0.0` instruction.
- **`AGENTS.md`** — the breaking-change clause now defers to `CONTRIBUTING.md` and points at the pre-1.0 note, instead of hard-coding "bump the Major version" (keeps the two docs consistent on the decision path).
- **`src/Directory.Build.props`** — comment at the version properties reminding whoever raises `MajorVersion` to `1` to remove the temporary note (an anchor at the exact spot the version is edited).

## Testing

- `cd src && dotnet build repo.slnx -c Release -warnaserror` → **0 warnings, 0 errors** (validates the new XML comment; version still resolves to 0.2.0)
- `cd src && dotnet test repo.slnx -c Release` → **27/27 passing on net48, net8.0, net10.0**
- Decision-path check: reading `AGENTS.md` → `CONTRIBUTING.md` for a breaking change at `MajorVersion=0` yields one unambiguous instruction (don't bump Major; bump Minor unless explicitly told).

🤖 Generated with [Claude Code](https://claude.com/claude-code)