### PR TITLE
fix: repair NuGet push and add package README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,14 @@ jobs:
     - name: Pack nugets
       run: dotnet pack -c Release --no-build WindyCliffs.Clock/WindyCliffs.Clock.csproj --output out/
     - name: Push to NuGet
-      run: dotnet nuget push out/*.nupkg --api-key ${{secrets.nuget_publish}} --source https://api.nuget.org/v3/index.json
+      shell: pwsh
+      # Pass the API key via env (kept out of the command-line argument vector).
+      env:
+        NUGET_API_KEY: ${{ secrets.nuget_publish }}
+      # Resolve the package explicitly: dotnet nuget push does not expand the
+      # out/*.nupkg wildcard, and PowerShell passes it through literally on the
+      # Windows runner. (Get-ChildItem runs relative to working-directory: src.)
+      run: |
+        $package = Get-ChildItem -Path out -Filter *.nupkg | Select-Object -First 1
+        if (-not $package) { throw "No .nupkg found in out/." }
+        dotnet nuget push $package.FullName --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ NuGet as `WindyCliffs.Clock`.
     ├── .editorconfig            # Code style
     ├── repo.slnx                # Solution
     ├── WindyCliffs.Clock/       # Library (netstandard2.0)
+    │   ├── WindyCliffs.Clock.csproj # Package metadata (PackageReadmeFile etc.)
+    │   ├── README.md                # NuGet package README (shipped in the package)
     │   ├── IClock.cs
     │   ├── SystemClock.cs
     │   └── MockClock.cs
@@ -66,6 +68,10 @@ and `net10.0`.
 - The package version is bumped via `MajorVersion`/`MinorVersion`/`Revision` in
   `src/Directory.Build.props`, following the rules in
   [CONTRIBUTING.md](CONTRIBUTING.md). Record version changes in `CHANGELOG.md`.
+- The NuGet package README is `src/WindyCliffs.Clock/README.md` (shipped in the
+  package via `PackageReadmeFile` and rendered on nuget.org). It is **distinct
+  from the repo-root `README.md`** (which targets GitHub readers). Keep it
+  current whenever the public API or usage changes.
 
 ## Breaking changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,14 +29,16 @@ The package version is **not** edited in the `.csproj`. It is assembled in
 `src/Directory.Build.props` from three properties:
 
 ```xml
-<MajorVersion>0</MajorVersion>
-<MinorVersion>2</MinorVersion>
-<Revision>0</Revision>
+<MajorVersion>…</MajorVersion>
+<MinorVersion>…</MinorVersion>
+<Revision>…</Revision>
 ```
 
-These drive `Version`, `AssemblyVersion`, and `FileVersion`, and the library
-csproj reuses `Version` as the NuGet `PackageVersion`. To change the published
-version, bump the appropriate property here.
+(The above shows the structure only — the authoritative current values live in
+[`src/Directory.Build.props`](src/Directory.Build.props).) These drive `Version`,
+`AssemblyVersion`, and `FileVersion`, and the library csproj reuses `Version` as
+the NuGet `PackageVersion`. To change the published version, bump the appropriate
+property there.
 
 Apply these rules when deciding what to bump:
 
@@ -65,6 +67,21 @@ the standard rule 2 (breaking → Major) applies.
 
 Whenever you bump the version, record the change in
 [CHANGELOG.md](CHANGELOG.md) under the `[Unreleased]` section.
+
+## Package README
+
+The NuGet package ships a README that is rendered on nuget.org. It is a separate
+file from the repository-root `README.md` (which targets GitHub readers):
+
+- **Location:** `src/WindyCliffs.Clock/README.md`.
+- **How it is included:** `WindyCliffs.Clock.csproj` sets
+  `<PackageReadmeFile>README.md</PackageReadmeFile>` and packs the file via a
+  `<None Include="README.md" Pack="true" PackagePath="/" />` item. The file must
+  exist at build time — `GeneratePackageOnBuild` packs it during `dotnet build`,
+  so a missing or misnamed file fails the build with `NU5039`.
+- **When to update:** keep it current whenever the public API or recommended
+  usage changes, so consumers browsing nuget.org see accurate guidance. It is
+  aimed at external consumers — keep it concise and example-led.
 
 ## Releasing
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,8 +2,12 @@
 	<PropertyGroup>
 		<Product>WindyCliffs.Clock</Product>
 		<Company>Windy Cliffs</Company>
+		<Authors>Windy Cliffs</Authors>
 		<Copyright>Copyright © 2023</Copyright>
 		<Description>The library for testable time management.</Description>
+		<PackageProjectUrl>https://github.com/windycliffs/clock</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/windycliffs/clock</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
 
 		<!-- Pre-1.0 exception active: while MajorVersion is 0, breaking changes do NOT bump
 		     Major (see CONTRIBUTING.md "Pre-1.0 versioning"). Remove that note when raising to 1. -->

--- a/src/WindyCliffs.Clock/README.md
+++ b/src/WindyCliffs.Clock/README.md
@@ -1,0 +1,80 @@
+# WindyCliffs.Clock
+
+A small .NET library for testable time. It abstracts the clock behind a single
+`IClock` interface so code that reads the current time, sleeps, or delays can be
+driven deterministically in tests instead of depending on the wall clock.
+
+- **`SystemClock`** — the production implementation, bound to the operating-system clock.
+- **`MockClock`** — a fully code-controlled clock for deterministic tests; you advance time yourself.
+
+Targets `netstandard2.0`, so it runs on .NET Framework and modern .NET alike.
+
+## Install
+
+```
+dotnet add package WindyCliffs.Clock
+```
+
+## Quick start
+
+Depend on `IClock` instead of calling `DateTimeOffset.UtcNow`, `Thread.Sleep`,
+or `Task.Delay` directly:
+
+```csharp
+using WindyCliffs.Clock;
+
+public sealed class Session
+{
+    private readonly IClock clock;
+
+    public Session(IClock clock) => this.clock = clock;
+
+    public bool HasExpired(DateTimeOffset expiresAt) => this.clock.UtcNow >= expiresAt;
+}
+```
+
+In production, register the singleton operating-system clock:
+
+```csharp
+services.AddSingleton<IClock>(SystemClock.Instance);
+```
+
+In tests, use `MockClock` and advance time yourself — no real waiting:
+
+```csharp
+var clock = new MockClock();
+var session = new Session(clock);
+
+clock.AdvanceBy(TimeSpan.FromMinutes(5));
+Assert.True(session.HasExpired(clock.UtcNow));
+```
+
+## What `IClock` offers
+
+| Member | Description |
+| --- | --- |
+| `UtcNow` | The current time (UTC). Replacement for `DateTimeOffset.UtcNow`. |
+| `Sleep(timeout)` | Blocks the caller. Replacement for `Thread.Sleep`. |
+| `TaskDelay(timeout, cancellationToken)` | Awaitable, cancellable delay. Replacement for `Task.Delay`. |
+
+With `MockClock`, both `Sleep` and `TaskDelay` are released by advancing the
+clock (`AdvanceBy`/`AdvanceTo`) rather than by real elapsed time, so
+time-dependent code — including `async` code — stays deterministic:
+
+```csharp
+var clock = new MockClock();
+
+Task delay = clock.TaskDelay(TimeSpan.FromSeconds(30));
+
+clock.AdvanceBy(TimeSpan.FromSeconds(30)); // releases the pending delay
+await delay;
+```
+
+## Documentation
+
+Full guides live in the GitHub repository:
+
+- [Usage](https://github.com/windycliffs/clock/blob/HEAD/docs/USAGE.md) — detailed API guide.
+- [Architecture](https://github.com/windycliffs/clock/blob/HEAD/docs/ARCHITECTURE.md) — how the abstraction and `MockClock` time-advancement are designed.
+
+The source lives at [github.com/windycliffs/clock](https://github.com/windycliffs/clock).

--- a/src/WindyCliffs.Clock/WindyCliffs.Clock.csproj
+++ b/src/WindyCliffs.Clock/WindyCliffs.Clock.csproj
@@ -8,6 +8,12 @@
 		<PackageId>WindyCliffs.Clock</PackageId>
 		<PackageVersion>$(Version)</PackageVersion>
 		<PackageTags>clock, dependency injection, test, mock</PackageTags>
+		<!-- README is library-project-relative, so it lives here rather than in Directory.Build.props. -->
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="README.md" Pack="true" PackagePath="/" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Fixes two NuGet packaging problems with the release pipeline and the published package.

**1. `Push to NuGet` step failed with `File does not exist (out/*.nupkg)`.**
`dotnet nuget push` does not glob-expand the `out/*.nupkg` argument, and PowerShell on the `windows-latest` runner passes the literal token through — so dotnet looked for a file literally named `*.nupkg`. (Reproduced locally: the `.nupkg` exists in `src/out/` yet the push reports the exact CI error.) The step now resolves the package path explicitly in a `pwsh` step and pushes that.

**2. The package shipped without a README.** `dotnet pack` warned *"The package WindyCliffs.Clock.0.3.0 is missing a readme."* Added a consumer-focused package README and wired it into the package.

## Notable changes

- **`.github/workflows/release.yml`** — resolve the `.nupkg` via `Get-ChildItem` and push the concrete path; pass the API key through `env:` (kept out of the command-line argument vector); add `--skip-duplicate` for idempotent re-runs.
- **`src/WindyCliffs.Clock/README.md`** (new) — concise, example-led README for nuget.org. Doc links use `blob/HEAD/` so they survive a default-branch rename.
- **`WindyCliffs.Clock.csproj`** — `<PackageReadmeFile>README.md</PackageReadmeFile>` + a `<None Include="README.md" Pack="true" PackagePath="/" />` item.
- **`src/Directory.Build.props`** — `PackageProjectUrl`, `RepositoryUrl`, `RepositoryType`, and `Authors` so the nuget.org listing is complete.
- **`AGENTS.md` / `CONTRIBUTING.md`** — document the package README's location, how it's embedded (`PackageReadmeFile`, NU5039 if missing), that it's distinct from the repo-root README, and when to update it. Also made the CONTRIBUTING versioning snippet version-agnostic.

**No version bump / no CHANGELOG entry** — `0.3.0` is verified unpublished on nuget.org (only `0.1.0`/`0.2.0` exist), and these are CI + packaging-metadata changes, not library interface/behavior changes.

## Testing

- `dotnet build -c Release repo.slnx -warnaserror` → **0 warnings, 0 errors** (also proves the `GeneratePackageOnBuild` path packs the README without NU5039).
- `dotnet test -c Release repo.slnx` → **45/45 pass** on `net48`, `net8.0`, `net10.0`.
- `dotnet pack` → the "missing a readme" warning is gone.
- Inspected both the `out/` and `bin/Release/` packages: each contains `README.md` at the root, with `<readme>`, `<authors>`, `<projectUrl>`, and `<repository url=…>` in the nuspec.
- Verified the new push command resolves the file (attempts the push and fails only on a deliberately bogus test source — no longer "File does not exist").

🤖 Generated with [Claude Code](https://claude.com/claude-code)