### PR TITLE
ci: publish to NuGet via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ jobs:
   build:
     runs-on: windows-latest
     timeout-minutes: 5
+    permissions:
+      id-token: write   # mint the GitHub OIDC token for NuGet trusted publishing
+      contents: read    # required for actions/checkout once a permissions block is set
     defaults:
       run:
         working-directory: src
@@ -27,15 +30,24 @@ jobs:
       run: dotnet test -c Release --no-build repo.slnx
     - name: Pack nugets
       run: dotnet pack -c Release --no-build WindyCliffs.Clock/WindyCliffs.Clock.csproj --output out/
+    - name: NuGet login (OIDC -> temporary API key)
+      # Exchanges the GitHub OIDC token for a short-lived (1-hour) nuget.org API
+      # key via trusted publishing — no long-lived secret. Run just before push.
+      # Pinned to a commit SHA (the v1.2.0 release) for supply-chain safety.
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841  # v1.2.0
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
     - name: Push to NuGet
       shell: pwsh
-      # Pass the API key via env (kept out of the command-line argument vector).
+      # Pass the temporary key via env (kept out of the command-line argument vector).
       env:
-        NUGET_API_KEY: ${{ secrets.nuget_publish }}
+        NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
       # Resolve the package explicitly: dotnet nuget push does not expand the
       # out/*.nupkg wildcard, and PowerShell passes it through literally on the
       # Windows runner. (Get-ChildItem runs relative to working-directory: src.)
       run: |
         $package = Get-ChildItem -Path out -Filter *.nupkg | Select-Object -First 1
         if (-not $package) { throw "No .nupkg found in out/." }
+        if (-not $env:NUGET_API_KEY) { throw "NUGET_API_KEY is empty — the NuGet login (OIDC) step may have failed." }
         dotnet nuget push $package.FullName --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ NuGet as `WindyCliffs.Clock`.
 │   ├── ARCHITECTURE.md  # Design of the abstraction and MockClock mechanism
 │   └── USAGE.md         # Detailed API usage
 ├── .github/workflows/
-│   └── release.yml      # Builds, tests, packs, and pushes to NuGet on release
+│   └── release.yml      # Builds, tests, packs, publishes to NuGet via OIDC trusted publishing
 └── src/                 # Build root — all build artefacts live here
     ├── global.json              # Pins the .NET 10 SDK band
     ├── Directory.Build.props    # Shared props + package version metadata

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,3 +90,29 @@ Publishing is automated. Creating a **published GitHub Release** triggers
 `WindyCliffs.Clock`, and pushes the resulting package to NuGet. Make sure the
 version in `src/Directory.Build.props` and the `CHANGELOG.md` entry are updated
 before tagging the release.
+
+### NuGet authentication (trusted publishing)
+
+The workflow authenticates to nuget.org with **trusted publishing (OIDC)** — it
+exchanges a GitHub-issued OIDC token for a short-lived (one-hour) API key at
+publish time, so there is no long-lived API key stored in the repository.
+
+This requires a **one-time setup that must be done before the first release is
+triggered**, or the workflow fails at the `NuGet login` step and the package is
+not published:
+
+1. On nuget.org, create a **Trusted Publishing** policy (under your account →
+   *Trusted Publishing*) with: Repository Owner `windycliffs`, Repository
+   `clock`, Workflow File `release.yml` (file name only), and no environment. If
+   you later add a GitHub Environment (`environment:` on the job), update the
+   policy to match the environment name or the OIDC exchange will fail.
+2. Add a repository secret **`NUGET_USER`** (GitHub repo → *Settings* →
+   *Secrets and variables* → *Actions* → *New repository secret*) containing your
+   nuget.org **account username / profile name** (e.g. `windycliffs`) — **not**
+   your account email.
+
+The legacy `nuget_publish` API-key secret is no longer referenced by the
+workflow, so on its own it is not a working rollback path. Retain it until the
+first OIDC-authenticated publish succeeds; to roll back you would revert
+`release.yml` to the API-key version **and** rely on that still-present secret.
+Once OIDC publishing is confirmed working, the secret can be deleted.


### PR DESCRIPTION
## Summary

Migrates the release pipeline from a long-lived NuGet API key (`secrets.nuget_publish`) to **NuGet trusted publishing (OIDC)**. The workflow now mints a short-lived (one-hour) API key at publish time by exchanging a GitHub OIDC token, so no publishing secret is stored in the repository — eliminating the leaked-credential risk and key-rotation burden.

## Notable changes

- **`.github/workflows/release.yml`**
  - Added job-level `permissions: { id-token: write, contents: read }` (the OIDC scope, plus `contents: read` for checkout since declaring a permissions block drops unlisted scopes).
  - Added a `NuGet login` step (`NuGet/login@…`) between `Pack nugets` and `Push to NuGet` so the 1-hour key is fresh; **pinned to the v1.2.0 commit SHA** (`8d19675`) for supply-chain safety.
  - The push step now consumes the temporary key via `env` (kept off the command-line argument vector) and has an empty-key guard that fails fast with a clear message if the OIDC exchange fails. Kept the `Get-ChildItem` glob-resolution and `--skip-duplicate`.
- **`CONTRIBUTING.md`** — documented the new mechanism and the **one-time setup required before the first release**: a nuget.org Trusted Publishing policy (owner `windycliffs`, repo `clock`, workflow `release.yml`, no environment) and a `NUGET_USER` secret (nuget.org username, not email). Clarified that the legacy `nuget_publish` secret is no longer a standalone rollback path and may be deleted only after the first successful OIDC publish.
- **`AGENTS.md`** — updated the `release.yml` description to note OIDC trusted publishing.

## Required before the next release (maintainer, outside this PR)

1. Create the nuget.org Trusted Publishing policy (see CONTRIBUTING.md).
2. Add the `NUGET_USER` repository secret.

Without these, the next release fails at the `NuGet login` step.

## Testing

- Workflow YAML validated (parses; permissions block, step order, and `id: login` ↔ `steps.login.outputs.NUGET_API_KEY` wiring confirmed).
- `dotnet build -c Release repo.slnx -warnaserror` → **0 warnings, 0 errors**.
- `dotnet test -c Release repo.slnx` → **45/45 pass** on `net48`, `net8.0`, `net10.0`.
- Full OIDC publish is verifiable only by a real release once the nuget.org policy and `NUGET_USER` secret exist (deploy-time verification).

**No version bump / no CHANGELOG entry** — CI-only change, not a library interface/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)