### PR TITLE
feat: add MIT license to the package and bump to 0.3.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ NuGet as `WindyCliffs.Clock`.
 ```
 .
 ├── README.md            # Overview + quick start
+├── LICENSE              # MIT license
 ├── CHANGELOG.md         # Keep a Changelog history
 ├── CONTRIBUTING.md      # Build/test + versioning rules
 ├── AGENTS.md            # This file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.3.1]
+
+### Added
+- MIT license declared on the NuGet package (`PackageLicenseExpression`).
+
 ## [0.3.0]
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,9 @@ Major bump**. This overrides rule 2 above for as long as the project is pre-1.0.
 **Remove this entire subsection once the version reaches `1.0.0`**, after which
 the standard rule 2 (breaking → Major) applies.
 
-Whenever you bump the version, record the change in
-[CHANGELOG.md](CHANGELOG.md) under the `[Unreleased]` section.
+Whenever you bump the version, add a new `## [X.Y.Z]` section at the top of
+[CHANGELOG.md](CHANGELOG.md), with the version matching the one set in
+`src/Directory.Build.props`.
 
 ## Package README
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright © 2023 Windy Cliffs
+Copyright © 2023-2026 Windy Cliffs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright © 2023 Windy Cliffs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -61,3 +61,7 @@ cd src
 dotnet build repo.slnx
 dotnet test repo.slnx
 ```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
 		<Product>WindyCliffs.Clock</Product>
 		<Company>Windy Cliffs</Company>
 		<Authors>Windy Cliffs</Authors>
-		<Copyright>Copyright © 2023 Windy Cliffs</Copyright>
+		<Copyright>Copyright © 2023-2026 Windy Cliffs</Copyright>
 		<Description>The library for testable time management.</Description>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/windycliffs/clock</PackageProjectUrl>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,8 +3,9 @@
 		<Product>WindyCliffs.Clock</Product>
 		<Company>Windy Cliffs</Company>
 		<Authors>Windy Cliffs</Authors>
-		<Copyright>Copyright © 2023</Copyright>
+		<Copyright>Copyright © 2023 Windy Cliffs</Copyright>
 		<Description>The library for testable time management.</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/windycliffs/clock</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/windycliffs/clock</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
@@ -13,7 +14,7 @@
 		     Major (see CONTRIBUTING.md "Pre-1.0 versioning"). Remove that note when raising to 1. -->
 		<MajorVersion>0</MajorVersion>
 		<MinorVersion>3</MinorVersion>
-		<Revision>0</Revision>
+		<Revision>1</Revision>
 		<Version>$(MajorVersion).$(MinorVersion).$(Revision)</Version>
 		<AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
 		<FileVersion>$(Version).0</FileVersion>

--- a/src/WindyCliffs.Clock/README.md
+++ b/src/WindyCliffs.Clock/README.md
@@ -78,3 +78,7 @@ Full guides live in the GitHub repository:
 - [Architecture](https://github.com/windycliffs/clock/blob/HEAD/docs/ARCHITECTURE.md) — how the abstraction and `MockClock` time-advancement are designed.
 
 The source lives at [github.com/windycliffs/clock](https://github.com/windycliffs/clock).
+
+## License
+
+MIT — see [LICENSE](https://github.com/windycliffs/clock/blob/HEAD/LICENSE).


### PR DESCRIPTION
## Summary

Adds an MIT license to the `WindyCliffs.Clock` NuGet package (it previously shipped with no license) and bumps the version `0.3.0` → `0.3.1`. Since `0.3.0` is already published to nuget.org, the license ships as a new release rather than a re-publish.

## Notable changes

- **`LICENSE`** (new, repo root) — standard MIT text, `Copyright © 2023 Windy Cliffs`. Lets GitHub detect the license.
- **`src/Directory.Build.props`**
  - `<PackageLicenseExpression>MIT</PackageLicenseExpression>` — the SPDX expression is the recommended way to declare a standard license; nuget.org renders it as a linked "MIT" and license scanners/SBOM tools can detect it.
  - `<Copyright>` now includes the author (`Copyright © 2023 Windy Cliffs`), matching the LICENSE file.
  - Bumped `Revision` `0` → `1` → version `0.3.1` (`FileVersion` `0.3.1.0`; `AssemblyVersion` stays `0.0.0.0`).
- **`CHANGELOG.md`** — preserved the published `## [0.3.0]` and added `## [0.3.1]` recording the license addition under `Added`.
- **`CONTRIBUTING.md`** — fixed a stale `[Unreleased]` versioning instruction to match the actual convention (a new `## [X.Y.Z]` top section matching `Directory.Build.props`).
- **`README.md`** / **`src/WindyCliffs.Clock/README.md`** — added License sections.
- **`AGENTS.md`** — added `LICENSE` to the layout tree.

The license is declared via the SPDX expression, **not** a packed file — the repo-root `LICENSE` is for GitHub and is intentionally not included in the package.

## Testing

- `dotnet build -c Release repo.slnx -warnaserror` → **0 warnings, 0 errors**.
- `dotnet test -c Release repo.slnx` → **45/45 pass** on `net48`, `net8.0`, `net10.0`.
- `dotnet pack` → no license warnings (NU5034/NU5125).
- Unzipped the produced `.nupkg`: nuspec has `<license type="expression">MIT</license>` and `<version>0.3.1</version>`, `README.md` is at the root, and no `LICENSE` file is packed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)