### PR TITLE
feat: add IClock.CancelAfter(CancellationTokenSource, TimeSpan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.4.0]
+
+### Added
+- `IClock.CancelAfter(CancellationTokenSource, TimeSpan)` with `SystemClock`
+  (delegates to `CancellationTokenSource.CancelAfter`) and `MockClock` (cancels
+  the source when the clock is advanced past the timeout, driven by the existing
+  `AdvanceBy`/`AdvanceTo` time-advancement machinery) implementations. A source
+  disposed after the call, while the cancellation is still pending, is ignored;
+  an already-disposed source throws `ObjectDisposedException`, mirroring the
+  underlying `CancellationTokenSource.CancelAfter`.
+
 ## [0.3.1]
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,6 +15,7 @@ public interface IClock
     DateTimeOffset UtcNow { get; }
     void Sleep(TimeSpan timeout);
     Task TaskDelay(TimeSpan timeout, CancellationToken cancellationToken = default);
+    void CancelAfter(CancellationTokenSource source, TimeSpan timeout);
 }
 ```
 
@@ -31,6 +32,9 @@ stateless singleton exposed through `SystemClock.Instance`:
 - `UtcNow` returns `DateTimeOffset.UtcNow`.
 - `Sleep(timeout)` delegates to `Thread.Sleep(timeout)`.
 - `TaskDelay(timeout, cancellationToken)` delegates to `Task.Delay(timeout, cancellationToken)`.
+- `CancelAfter(source, timeout)` delegates to `source.CancelAfter(timeout)` (after a
+  null check on `source`, so a null argument yields `ArgumentNullException` rather
+  than `NullReferenceException`).
 
 ### `MockClock`
 
@@ -89,6 +93,44 @@ it completes a `TaskCompletionSource`:
 Unlike infinite `Sleep` — which blocks a real OS thread that only a thread
 interrupt can release — `TaskDelay(Timeout.InfiniteTimeSpan)` schedules nothing
 and is released only by cancelling the token, never by advancing the clock.
+
+## How `MockClock.CancelAfter` works
+
+`MockClock.CancelAfter` reuses the same `ScheduledAction` mechanism as `Sleep`
+and `TaskDelay`, but the scheduled action calls `source.Cancel()`:
+
+1. `CancelAfter(source, timeout)` validates its arguments (null `source` throws
+   `ArgumentNullException`; a negative non-infinite `timeout` throws
+   `ArgumentOutOfRangeException`) and then probes `source.Token`, which throws
+   `ObjectDisposedException` if the source is **already** disposed — surfacing
+   that programming error synchronously, exactly as the real
+   `CancellationTokenSource.CancelAfter` does. For `Timeout.InfiniteTimeSpan` it
+   returns without scheduling anything.
+2. Otherwise it creates a fire-and-forget `ScheduledAction` targeted at
+   `UtcNow + timeout`. A `TimeSpan.Zero` timeout fires synchronously inside the
+   `ScheduledAction` constructor (which checks the current time); a positive
+   timeout fires when the clock is advanced past the target. The action cancels
+   `source` and the `ScheduledAction` self-disposes.
+3. The `source.Cancel()` call is wrapped in a `try`/`catch (ObjectDisposedException)`
+   so that a source disposed **after** the call, while the cancellation is still
+   pending, is handled gracefully — advancing the clock does not propagate the
+   exception. The catch is deliberately narrow, so errors thrown by
+   user-registered cancellation callbacks still surface.
+
+Because `source.Cancel()` runs from a `Changed` handler, registered cancellation
+callbacks run synchronously on the thread driving `AdvanceBy`/`AdvanceTo`,
+consistent with how `MockClock` raises `Changed` in general.
+
+Two intentional simplifications, appropriate for a test double:
+
+- Each call schedules an **independent** cancellation rather than rescheduling a
+  previous one, so the earliest deadline reached cancels the source and later
+  scheduled cancellations become harmless no-ops.
+- A `CancelAfter` whose deadline is never reached leaves one `ScheduledAction`
+  subscribed to `Changed` for the clock's lifetime (holding the source closure);
+  it is released only when the deadline is reached or the `MockClock` is
+  collected. There is no disposal hook on `CancellationTokenSource` to key off,
+  and this mirrors a real pending `CancelAfter` timer.
 
 ## Target frameworks and build layout
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -49,6 +49,8 @@ The operating-system clock:
 - `SystemClock.Instance.Sleep(timeout)` delegates to `Thread.Sleep(timeout)`.
 - `SystemClock.Instance.TaskDelay(timeout, cancellationToken)` delegates to
   `Task.Delay(timeout, cancellationToken)`.
+- `SystemClock.Instance.CancelAfter(source, timeout)` delegates to
+  `source.CancelAfter(timeout)`.
 
 Use it in production; use `MockClock` in tests.
 
@@ -163,3 +165,44 @@ clock.AdvanceBy(TimeSpan.FromSeconds(30));
 
 await delay; // completes immediately
 ```
+
+### `CancelAfter` semantics
+
+`MockClock.CancelAfter` schedules the cancellation of a
+`CancellationTokenSource` and, like `Sleep` and `TaskDelay`, is driven by time
+advancement rather than wall-clock time:
+
+| `timeout`                   | Behaviour                                                                                          |
+| --------------------------- | -------------------------------------------------------------------------------------------------- |
+| `TimeSpan.Zero`             | Cancels `source` immediately (synchronously, during the call).                                     |
+| Positive, finite            | Cancels `source` once the clock is advanced to `UtcNow + timeout`.                                 |
+| `Timeout.InfiniteTimeSpan`  | Schedules nothing; `source` is never cancelled by this call, no matter how far the clock advances. |
+| Negative (and not infinite) | Throws `ArgumentOutOfRangeException`.                                                               |
+
+A `null` `source` throws `ArgumentNullException`.
+
+Disposal is handled the same way as the real `CancellationTokenSource.CancelAfter`:
+
+- If `source` is disposed **after** the call, while the cancellation is still
+  pending, the pending cancellation is silently dropped — advancing the clock
+  past the deadline does **not** throw `ObjectDisposedException`.
+- If `source` is **already** disposed when `CancelAfter` is called, that is a
+  programming error and throws `ObjectDisposedException` synchronously.
+
+A pending cancellation is triggered by advancing the clock, on the same thread:
+
+```csharp
+var clock = new MockClock();
+using var cts = new CancellationTokenSource();
+
+clock.CancelAfter(cts, TimeSpan.FromSeconds(30));
+
+// The source is not cancelled until we move time forward:
+clock.AdvanceBy(TimeSpan.FromSeconds(30));
+
+Assert.True(cts.IsCancellationRequested);
+```
+
+Each call schedules an independent cancellation rather than rescheduling a
+previous one, so the earliest deadline reached cancels the source; later
+scheduled cancellations then become harmless no-ops.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,8 +13,8 @@
 		<!-- Pre-1.0 exception active: while MajorVersion is 0, breaking changes do NOT bump
 		     Major (see CONTRIBUTING.md "Pre-1.0 versioning"). Remove that note when raising to 1. -->
 		<MajorVersion>0</MajorVersion>
-		<MinorVersion>3</MinorVersion>
-		<Revision>1</Revision>
+		<MinorVersion>4</MinorVersion>
+		<Revision>0</Revision>
 		<Version>$(MajorVersion).$(MinorVersion).$(Revision)</Version>
 		<AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
 		<FileVersion>$(Version).0</FileVersion>

--- a/src/WindyCliffs.Clock.Tests/MockClockTests.CancelAfter.cs
+++ b/src/WindyCliffs.Clock.Tests/MockClockTests.CancelAfter.cs
@@ -1,0 +1,142 @@
+namespace WindyCliffs.Clock.Tests
+{
+    using System;
+    using System.Threading;
+    using Xunit;
+
+    public partial class MockClockTests
+    {
+        [Fact]
+        public void CancelAfter_NullSource()
+        {
+            var clock = new MockClock();
+
+            Assert.Throws<ArgumentNullException>(() => clock.CancelAfter(null!, TimeSpan.FromSeconds(1)));
+        }
+
+        [Fact]
+        public void CancelAfter_NegativeTimeout()
+        {
+            var clock = new MockClock();
+            using var cts = new CancellationTokenSource();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => clock.CancelAfter(cts, TimeSpan.FromSeconds(-1)));
+        }
+
+        [Fact]
+        public void CancelAfter_ZeroTimeout_CancelsImmediately()
+        {
+            var clock = new MockClock();
+            using var cts = new CancellationTokenSource();
+
+            clock.CancelAfter(cts, TimeSpan.Zero);
+
+            Assert.True(cts.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void CancelAfter_AdvancePastDeadline_Cancels()
+        {
+            var clock = new MockClock();
+            using var cts = new CancellationTokenSource();
+            var timeout = TimeSpan.FromSeconds(10);
+
+            clock.CancelAfter(cts, timeout);
+
+            Assert.False(cts.IsCancellationRequested, "Source cancelled before the clock advanced.");
+
+            clock.AdvanceBy(timeout);
+
+            Assert.True(cts.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void CancelAfter_AdvanceUndershootThenReach()
+        {
+            var clock = new MockClock();
+            using var cts = new CancellationTokenSource();
+            var timeout = TimeSpan.FromSeconds(10);
+
+            clock.CancelAfter(cts, timeout);
+
+            clock.AdvanceBy(timeout - TimeSpan.FromSeconds(1));
+
+            Assert.False(cts.IsCancellationRequested, "Source cancelled before reaching the deadline.");
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(1));
+
+            Assert.True(cts.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void CancelAfter_InfiniteTimeout_NeverCancels()
+        {
+            var clock = new MockClock();
+            using var cts = new CancellationTokenSource();
+
+            clock.CancelAfter(cts, Timeout.InfiniteTimeSpan);
+
+            clock.AdvanceBy(TimeSpan.FromHours(1));
+
+            Assert.False(cts.IsCancellationRequested, "Infinite timeout cancelled the source by advancing the clock.");
+        }
+
+        [Fact]
+        public void CancelAfter_AlreadyCancelledSource_IsNoOp()
+        {
+            var clock = new MockClock();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            clock.CancelAfter(cts, TimeSpan.FromSeconds(10));
+
+            // Advancing past the deadline calls Cancel() again, which is a harmless no-op on an
+            // already-cancelled source and must not throw.
+            var exception = Record.Exception(() => clock.AdvanceBy(TimeSpan.FromSeconds(10)));
+
+            Assert.Null(exception);
+            Assert.True(cts.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void CancelAfter_DisposedSourceAtFireTime_DoesNotThrow()
+        {
+            var clock = new MockClock();
+            var cts = new CancellationTokenSource();
+
+            clock.CancelAfter(cts, TimeSpan.FromSeconds(10));
+
+            cts.Dispose();
+
+            // Advancing past the deadline fires the scheduled Cancel() on a disposed source; the
+            // ObjectDisposedException must be swallowed rather than escaping AdvanceBy.
+            var exception = Record.Exception(() => clock.AdvanceBy(TimeSpan.FromSeconds(10)));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void CancelAfter_DisposedSourceAtCallTime_Throws()
+        {
+            var clock = new MockClock();
+            var cts = new CancellationTokenSource();
+            cts.Dispose();
+
+            // An already-disposed source at call time is a programming error: it must surface
+            // synchronously rather than be swallowed (unlike disposal while a cancellation is pending).
+            Assert.Throws<ObjectDisposedException>(() => clock.CancelAfter(cts, TimeSpan.FromSeconds(10)));
+        }
+
+        [Fact]
+        public void CancelAfter_DisposedSourceAtCallTime_ZeroTimeout_Throws()
+        {
+            var clock = new MockClock();
+            var cts = new CancellationTokenSource();
+            cts.Dispose();
+
+            // The synchronous disposed check runs before any scheduling, so a zero timeout throws too
+            // rather than reaching the immediate-fire path.
+            Assert.Throws<ObjectDisposedException>(() => clock.CancelAfter(cts, TimeSpan.Zero));
+        }
+    }
+}

--- a/src/WindyCliffs.Clock.Tests/SystemClockTests.cs
+++ b/src/WindyCliffs.Clock.Tests/SystemClockTests.cs
@@ -138,5 +138,36 @@ namespace WindyCliffs.Clock.Tests
             await Assert.ThrowsAsync<TaskCanceledException>(() => delay);
             Assert.True(delay.IsCanceled);
         }
+
+        [Fact]
+        public void CancelAfter_NullSource()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => SystemClock.Instance.CancelAfter(null!, TimeSpan.FromSeconds(1)));
+        }
+
+        [Fact]
+        public void CancelAfter_NegativeTimeout()
+        {
+            using var cts = new CancellationTokenSource();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => SystemClock.Instance.CancelAfter(cts, TimeSpan.FromSeconds(-1)));
+        }
+
+        [Fact]
+        public void CancelAfter_CancelsAfterDelay()
+        {
+            using var cts = new CancellationTokenSource();
+
+            SystemClock.Instance.CancelAfter(cts, TimeSpan.FromMilliseconds(50));
+
+            int signaled = WaitHandle.WaitAny(
+                new[] { cts.Token.WaitHandle, TestContext.Current.CancellationToken.WaitHandle },
+                TimeSpan.FromSeconds(5));
+
+            Assert.Equal(0, signaled);
+            Assert.True(cts.IsCancellationRequested);
+        }
     }
 }

--- a/src/WindyCliffs.Clock/IClock.cs
+++ b/src/WindyCliffs.Clock/IClock.cs
@@ -54,5 +54,35 @@
         /// <see cref="Timeout.InfiniteTimeSpan"/>.
         /// </exception>
         Task TaskDelay(TimeSpan timeout, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Schedules the cancellation of the given <see cref="CancellationTokenSource"/> after the
+        /// specified amount of time elapses.
+        /// Replacement for <see cref="CancellationTokenSource.CancelAfter(TimeSpan)"/>.
+        /// </summary>
+        /// <param name="source">The cancellation token source to cancel once the timeout elapses.</param>
+        /// <param name="timeout">
+        /// The amount of time to wait before cancelling <paramref name="source"/>. A value of
+        /// <see cref="TimeSpan.Zero"/> requests cancellation immediately. A value of
+        /// <see cref="Timeout.InfiniteTimeSpan"/> disables the scheduled cancellation, so
+        /// <paramref name="source"/> is never cancelled by this call.
+        /// </param>
+        /// <remarks>
+        /// A <paramref name="source"/> that is disposed <em>after</em> this call returns, while the
+        /// cancellation is still pending, is tolerated: the pending cancellation is silently dropped. A
+        /// <paramref name="source"/> that is <em>already</em> disposed when this method is called is a
+        /// programming error and throws <see cref="ObjectDisposedException"/>.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// When <paramref name="source"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// When <paramref name="timeout"/> is negative and is not equal to
+        /// <see cref="Timeout.InfiniteTimeSpan"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// When <paramref name="source"/> has already been disposed.
+        /// </exception>
+        void CancelAfter(CancellationTokenSource source, TimeSpan timeout);
     }
 }

--- a/src/WindyCliffs.Clock/MockClock.cs
+++ b/src/WindyCliffs.Clock/MockClock.cs
@@ -125,6 +125,53 @@
             return completion.Task;
         }
 
+        /// <inheritdoc />
+        public void CancelAfter(CancellationTokenSource source, TimeSpan timeout)
+        {
+            // Guard order mirrors TaskDelay: reference-type precondition first, then the timeout range.
+            if (source is null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeout), "The time-out value is negative and is not equal to Infinite.");
+            }
+
+            // Surface an already-disposed source synchronously, mirroring CancellationTokenSource.CancelAfter:
+            // disposing then calling is a programming error worth raising. Only a source disposed *after* this
+            // call, while the cancellation is still pending, is tolerated (handled in the action below). The
+            // Token getter throws ObjectDisposedException on a disposed source.
+            _ = source.Token;
+
+            // An infinite timeout schedules nothing, mirroring CancellationTokenSource.CancelAfter, which
+            // treats Timeout.InfiniteTimeSpan as "no scheduled cancellation".
+            if (timeout == Timeout.InfiniteTimeSpan)
+            {
+                return;
+            }
+
+            // Fire-and-forget: the ScheduledAction self-disposes once it cancels the source, so no local
+            // reference is kept (hence the discard). For a zero timeout the action fires synchronously
+            // inside the constructor (it checks the current time); for a positive timeout it fires when
+            // the clock advances to UtcNow + timeout. The catch lives inside the action so it covers both
+            // paths; it is narrowed to ObjectDisposedException so that a source disposed while the
+            // cancellation is pending is tolerated, while errors thrown by user-registered cancellation
+            // callbacks still surface.
+            _ = new ScheduledAction(this, this.UtcNow + timeout, () =>
+            {
+                try
+                {
+                    source.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // The source was disposed before the deadline was reached; there is nothing to cancel.
+                }
+            });
+        }
+
         /// <summary>
         /// Gets or sets the advancement step used by <see cref="AdvanceBy(TimeSpan)"/> and
         /// <see cref="AdvanceTo(DateTimeOffset)"/> methods.

--- a/src/WindyCliffs.Clock/README.md
+++ b/src/WindyCliffs.Clock/README.md
@@ -56,10 +56,11 @@ Assert.True(session.HasExpired(clock.UtcNow));
 | `UtcNow` | The current time (UTC). Replacement for `DateTimeOffset.UtcNow`. |
 | `Sleep(timeout)` | Blocks the caller. Replacement for `Thread.Sleep`. |
 | `TaskDelay(timeout, cancellationToken)` | Awaitable, cancellable delay. Replacement for `Task.Delay`. |
+| `CancelAfter(source, timeout)` | Cancels a `CancellationTokenSource` after the timeout. Replacement for `CancellationTokenSource.CancelAfter`. |
 
-With `MockClock`, both `Sleep` and `TaskDelay` are released by advancing the
-clock (`AdvanceBy`/`AdvanceTo`) rather than by real elapsed time, so
-time-dependent code — including `async` code — stays deterministic:
+With `MockClock`, `Sleep`, `TaskDelay`, and `CancelAfter` are all driven by
+advancing the clock (`AdvanceBy`/`AdvanceTo`) rather than by real elapsed time,
+so time-dependent code — including `async` code — stays deterministic:
 
 ```csharp
 var clock = new MockClock();

--- a/src/WindyCliffs.Clock/SystemClock.cs
+++ b/src/WindyCliffs.Clock/SystemClock.cs
@@ -25,5 +25,18 @@
         /// <inheritdoc />
         public Task TaskDelay(TimeSpan timeout, CancellationToken cancellationToken = default)
             => Task.Delay(timeout, cancellationToken);
+
+        /// <inheritdoc />
+        public void CancelAfter(CancellationTokenSource source, TimeSpan timeout)
+        {
+            // Enforce the IClock contract's ArgumentNullException; a bare delegate on a null receiver
+            // would throw NullReferenceException instead.
+            if (source is null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            source.CancelAfter(timeout);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a new `CancelAfter` member to the `IClock` abstraction so time-driven cancellation can be tested deterministically alongside the existing `Sleep`/`TaskDelay` surface.

```csharp
void CancelAfter(CancellationTokenSource source, TimeSpan timeout);
```

## Notable changes

- **`SystemClock`** delegates to `CancellationTokenSource.CancelAfter(timeout)` — a faithful pass-through. A `null` source is converted to `ArgumentNullException` to honour the documented `IClock` contract (a bare delegate would throw `NullReferenceException`).
- **`MockClock`** schedules the cancellation through the existing private `ScheduledAction` machinery, cancelling the source when the clock is advanced past `UtcNow + timeout`. `TimeSpan.Zero` cancels immediately; `Timeout.InfiniteTimeSpan` schedules nothing; a negative non-infinite timeout throws `ArgumentOutOfRangeException`.
- **Disposal semantics** (consistent across both implementations):
  - A source disposed **after** the call, while the cancellation is still pending, is tolerated — the pending cancellation is silently dropped.
  - A source that is **already** disposed when `CancelAfter` is called surfaces `ObjectDisposedException` synchronously, mirroring the underlying BCL.
- **Version** bumped `0.3.1 → 0.4.0` (additive feature).
- **Docs** updated: package `README.md` API table, `docs/USAGE.md` (semantics table), `docs/ARCHITECTURE.md` (interface snippet + "How `MockClock.CancelAfter` works"), and `CHANGELOG.md`.

## Testing

- `dotnet build src/repo.slnx -warnaserror` — clean, **0 warnings**.
- `dotnet test src/repo.slnx` — **58/58 pass on net48, net8.0, and net10.0**.
- New tests cover: advance-past-deadline, undershoot-then-reach, zero/infinite/negative timeouts, null source, already-cancelled no-op, disposed-at-fire-time (tolerated), disposed-at-call-time (throws), and the `SystemClock` real-delay path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)