### PR TITLE
feat: add IClock.StartTimer for one-shot and periodic timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.5.0]
+
+### Added
+- `IClock.StartTimer(object?, TimeSpan, TimeSpan, TimerCallback)` with `SystemClock`
+  (creates a `System.Threading.Timer`) and `MockClock` (drives an internal
+  `MockTimer` from the existing `AdvanceBy`/`AdvanceTo` time-advancement machinery)
+  implementations. Argument handling matches the `System.Threading.Timer`
+  constructor; with `MockClock` the callback fires synchronously on the advancing
+  thread, once per elapsed interval when the clock jumps past several at once.
+
+### Changed
+- **Breaking:** `IClock` gains a member, so existing third-party implementations
+  must add `StartTimer`. Per the pre-1.0 versioning rule this is a minor bump.
+
 ## [0.4.1]
 
 ### Fixed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,6 +16,7 @@ public interface IClock
     void Sleep(TimeSpan timeout);
     Task TaskDelay(TimeSpan timeout, CancellationToken cancellationToken = default);
     void CancelAfter(CancellationTokenSource source, TimeSpan timeout);
+    IDisposable StartTimer(object? state, TimeSpan dueTime, TimeSpan interval, TimerCallback callback);
 }
 ```
 
@@ -35,6 +36,10 @@ stateless singleton exposed through `SystemClock.Instance`:
 - `CancelAfter(source, timeout)` delegates to `source.CancelAfter(timeout)` (after a
   null check on `source`, so a null argument yields `ArgumentNullException` rather
   than `NullReferenceException`).
+- `StartTimer(state, dueTime, interval, callback)` constructs a
+  `System.Threading.Timer(callback, state, dueTime, interval)` and returns it (the
+  timer is itself the `IDisposable`). All argument validation is the `Timer`
+  constructor's own.
 
 ### `MockClock`
 
@@ -144,6 +149,54 @@ One intentional limitation, appropriate for a test double:
   does not implement `IDisposable`, so there is no deterministic cleanup hook —
   this mirrors a real pending `CancelAfter` timer and is acceptable for a clock
   whose lifetime is a single test.
+
+## How `MockClock.StartTimer` works
+
+`MockClock.StartTimer` validates its arguments **exactly as the
+`System.Threading.Timer` constructor does** — each of `dueTime`/`interval` is
+truncated to whole milliseconds and must fall in `[-1, 0xFFFFFFFE]` (the ranges
+are checked before the null-callback check, matching the constructor's order) —
+and then hands off to an internal `MockTimer`:
+
+1. `dueTime`/`interval` are converted to `long` milliseconds (so a sub-millisecond
+   value collapses to zero and fires immediately, like a real `Timer`). The
+   `0xFFFFFFFE` upper bound is `Timer`'s fixed `MaxSupportedTimeout`, identical on
+   every target runtime, so `MockClock` and `SystemClock` reject the same values.
+2. A `MockTimer` is created from the truncated millisecond values.
+
+`MockTimer` resembles `ScheduledAction` — it subscribes to `Changed` at
+construction and checks the current time immediately so a zero/elapsed due time
+fires synchronously — but it is a **separate class**, because `ScheduledAction`'s
+fire-once-then-self-dispose invariant is incompatible with a periodic timer.
+Instead `MockTimer` holds a nullable `nextDueTime` and, on each `Changed`:
+
+1. Under its lock it checks whether `nextDueTime` has been reached; if so it
+   **claims the tick** by advancing `nextDueTime` (by `interval` if periodic, or to
+   `null` for a one-shot) *before* releasing the lock. Claiming under the lock means
+   a concurrent — or re-entrant — advance cannot fire the same tick twice.
+2. It then invokes the callback **outside** the lock (the callback is arbitrary
+   user code that may advance the clock or dispose the timer; neither must contend
+   for the lock while it is held — the same discipline `ScheduledCancellationCollection`
+   follows).
+3. It loops, so a single advance that crosses several intervals fires the callback
+   once per elapsed interval (**catch-up**), making the result independent of the
+   advancement step. A one-shot timer's `nextDueTime` becomes `null` after the
+   single fire, so the loop terminates.
+
+An infinite `dueTime` (`-1 ms`) sets `nextDueTime` to `null` at construction (no
+arithmetic on `UtcNow`, which would otherwise move the deadline into the past), so
+the timer never fires and can only be disposed. `Dispose` sets a disposed flag and
+unsubscribes from `Changed` under the lock; it is idempotent and safe from within
+the callback. A callback already in flight when `Dispose` runs may still complete,
+mirroring `System.Threading.Timer.Dispose()`.
+
+Three deliberate differences from a real `System.Threading.Timer`, all consistent
+with how `MockClock` already runs scheduled work: the callback runs **synchronously
+on the advancing thread** (not a thread-pool thread); missed intervals are **caught
+up** one-per-interval rather than coalesced; and an exception thrown by the callback
+**propagates** to the `AdvanceBy`/`AdvanceTo` caller (a real timer's thread-pool
+callback exception would crash the process), just as user cancellation callbacks
+surface through `CancelAfter`.
 
 ## Target frameworks and build layout
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,21 +152,19 @@ One intentional limitation, appropriate for a test double:
 
 ## How `MockClock.StartTimer` works
 
-`MockClock.StartTimer` validates its arguments **exactly as the
-`System.Threading.Timer` constructor does** — each of `dueTime`/`interval` is
-truncated to whole milliseconds and must fall in `[-1, 0xFFFFFFFE]` (the ranges
-are checked before the null-callback check, matching the constructor's order) —
-and then hands off to an internal `MockTimer`:
+`MockClock.StartTimer` simply constructs an internal `MockTimer`, which both
+validates the arguments and schedules itself. Validation matches the
+`System.Threading.Timer` constructor **exactly**: each of `dueTime`/`interval` is
+converted to `long` milliseconds (so a sub-millisecond value collapses to zero and
+fires immediately, like a real `Timer`) and must fall in `[-1, 0xFFFFFFFE]`, with
+the ranges checked before the null-callback check, matching the constructor's
+order. The `0xFFFFFFFE` upper bound is `Timer`'s fixed `MaxSupportedTimeout`,
+identical on every target runtime, so `MockClock` and `SystemClock` reject the same
+values.
 
-1. `dueTime`/`interval` are converted to `long` milliseconds (so a sub-millisecond
-   value collapses to zero and fires immediately, like a real `Timer`). The
-   `0xFFFFFFFE` upper bound is `Timer`'s fixed `MaxSupportedTimeout`, identical on
-   every target runtime, so `MockClock` and `SystemClock` reject the same values.
-2. A `MockTimer` is created from the truncated millisecond values.
-
-`MockTimer` resembles `ScheduledAction` — it subscribes to `Changed` at
-construction and checks the current time immediately so a zero/elapsed due time
-fires synchronously — but it is a **separate class**, because `ScheduledAction`'s
+`MockTimer` resembles `ScheduledAction` — when it has a due time it subscribes to
+`Changed` and checks the current time immediately so a zero/elapsed due time fires
+synchronously — but it is a **separate class**, because `ScheduledAction`'s
 fire-once-then-self-dispose invariant is incompatible with a periodic timer.
 Instead `MockTimer` holds a nullable `nextDueTime` and, on each `Changed`:
 
@@ -181,14 +179,16 @@ Instead `MockTimer` holds a nullable `nextDueTime` and, on each `Changed`:
 3. It loops, so a single advance that crosses several intervals fires the callback
    once per elapsed interval (**catch-up**), making the result independent of the
    advancement step. A one-shot timer's `nextDueTime` becomes `null` after the
-   single fire, so the loop terminates.
+   single fire, so the loop terminates. The moment `nextDueTime` becomes `null` —
+   meaning the timer can never fire again — `MockTimer` unsubscribes from `Changed`
+   so it does not linger on the clock's invocation list for the rest of the test.
 
 An infinite `dueTime` (`-1 ms`) sets `nextDueTime` to `null` at construction (no
 arithmetic on `UtcNow`, which would otherwise move the deadline into the past), so
-the timer never fires and can only be disposed. `Dispose` sets a disposed flag and
-unsubscribes from `Changed` under the lock; it is idempotent and safe from within
-the callback. A callback already in flight when `Dispose` runs may still complete,
-mirroring `System.Threading.Timer.Dispose()`.
+such a timer never even subscribes to `Changed`: it can only be disposed. `Dispose`
+sets a disposed flag and unsubscribes from `Changed` under the lock; it is
+idempotent and safe from within the callback. A callback already in flight when
+`Dispose` runs may still complete, mirroring `System.Threading.Timer.Dispose()`.
 
 Three deliberate differences from a real `System.Threading.Timer`, all consistent
 with how `MockClock` already runs scheduled work: the callback runs **synchronously

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -51,6 +51,8 @@ The operating-system clock:
   `Task.Delay(timeout, cancellationToken)`.
 - `SystemClock.Instance.CancelAfter(source, timeout)` delegates to
   `source.CancelAfter(timeout)`.
+- `SystemClock.Instance.StartTimer(state, dueTime, interval, callback)` creates a
+  `System.Threading.Timer(callback, state, dueTime, interval)`.
 
 Use it in production; use `MockClock` in tests.
 
@@ -210,3 +212,56 @@ exactly as `CancellationTokenSource.CancelAfter` does. Rescheduling to
 one. (A source that has already been cancelled cannot be un-cancelled, so
 rescheduling has a visible effect only while the earlier deadline is still
 pending.)
+
+### `StartTimer` semantics
+
+`MockClock.StartTimer` is the time-advancement-driven counterpart of the
+`System.Threading.Timer` constructor. It invokes `callback` (passing `state`)
+when the clock is advanced to `UtcNow + dueTime`, and — for a positive
+`interval` — again on every subsequent `interval`. It returns an `IDisposable`
+that stops the timer.
+
+`dueTime` and `interval` are validated exactly as the `Timer` constructor
+validates them (each truncated to whole milliseconds, then required to be
+between `-1` / `Timeout.InfiniteTimeSpan` and `4294967294` inclusive):
+
+| Argument                                  | Behaviour                                                                            |
+| ----------------------------------------- | ------------------------------------------------------------------------------------ |
+| `dueTime` `TimeSpan.Zero`                 | `callback` fires immediately, synchronously during the `StartTimer` call.            |
+| `dueTime` positive, finite                | `callback` fires once the clock is advanced to `UtcNow + dueTime`.                   |
+| `dueTime` `Timeout.InfiniteTimeSpan`      | The timer never fires; it can only be disposed.                                      |
+| `interval` positive                       | After the first fire, `callback` fires again on every `interval`.                    |
+| `interval` `TimeSpan.Zero` or infinite    | The timer is one-shot — `callback` fires only once (when `dueTime` elapses).         |
+| `dueTime`/`interval` out of range         | Throws `ArgumentOutOfRangeException` (`< -1 ms` or `> 4294967294 ms`).               |
+| `callback` `null`                         | Throws `ArgumentNullException`.                                                      |
+
+`Dispose()` stops future callbacks, is idempotent, and is safe to call after the
+timer has fired or from within the callback itself. (A callback already in
+progress when `Dispose()` is called may still run to completion, exactly as with
+`System.Threading.Timer.Dispose()`.)
+
+The callback runs synchronously on the thread that advances the clock — so a
+pending timer is driven from the same thread, just like `TaskDelay` and
+`CancelAfter`:
+
+```csharp
+var clock = new MockClock();
+var ticks = 0;
+
+using IDisposable timer = clock.StartTimer(
+    state: null,
+    dueTime: TimeSpan.FromSeconds(1),
+    interval: TimeSpan.FromSeconds(1),
+    callback: _ => ticks++);
+
+clock.AdvanceBy(TimeSpan.FromSeconds(5));
+
+Assert.Equal(5, ticks); // one tick per elapsed interval
+```
+
+Because the timer fires once per elapsed `interval`, the result is independent of
+the `AdvancementStep` used to advance the clock: advancing five seconds in one
+ten-second step or in five one-second steps both yield five ticks. (This differs
+from a real `Timer`, which runs its callback on a thread-pool thread and may
+coalesce missed ticks. An exception thrown by the callback likewise propagates to
+the `AdvanceBy`/`AdvanceTo` caller rather than being swallowed.)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,8 +13,8 @@
 		<!-- Pre-1.0 exception active: while MajorVersion is 0, breaking changes do NOT bump
 		     Major (see CONTRIBUTING.md "Pre-1.0 versioning"). Remove that note when raising to 1. -->
 		<MajorVersion>0</MajorVersion>
-		<MinorVersion>4</MinorVersion>
-		<Revision>1</Revision>
+		<MinorVersion>5</MinorVersion>
+		<Revision>0</Revision>
 		<Version>$(MajorVersion).$(MinorVersion).$(Revision)</Version>
 		<AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
 		<FileVersion>$(Version).0</FileVersion>

--- a/src/WindyCliffs.Clock.Tests/MockClockTests.StartTimer.cs
+++ b/src/WindyCliffs.Clock.Tests/MockClockTests.StartTimer.cs
@@ -1,0 +1,146 @@
+namespace WindyCliffs.Clock.Tests
+{
+    using System;
+    using System.Threading;
+    using Xunit;
+
+    public partial class MockClockTests
+    {
+        [Fact]
+        public void StartTimer_NullCallback()
+        {
+            var clock = new MockClock();
+
+            Assert.Throws<ArgumentNullException>(
+                () => clock.StartTimer(null, TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan, null!));
+        }
+
+        [Theory]
+        [InlineData(-2)]
+        [InlineData(4294967295)]
+        public void StartTimer_DueTimeOutOfRange(long dueMilliseconds)
+        {
+            var clock = new MockClock();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => clock.StartTimer(null, TimeSpan.FromMilliseconds(dueMilliseconds), Timeout.InfiniteTimeSpan, _ => { }));
+        }
+
+        [Theory]
+        [InlineData(-2)]
+        [InlineData(4294967295)]
+        public void StartTimer_IntervalOutOfRange(long intervalMilliseconds)
+        {
+            var clock = new MockClock();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => clock.StartTimer(null, TimeSpan.Zero, TimeSpan.FromMilliseconds(intervalMilliseconds), _ => { }));
+        }
+
+        [Fact]
+        public void StartTimer_ReturnsDisposable()
+        {
+            var clock = new MockClock();
+
+            using IDisposable timer = clock.StartTimer(null, TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan, _ => { });
+
+            Assert.NotNull(timer);
+        }
+
+        [Fact]
+        public void StartTimer_OneShot_FiresOnceAtDueTime()
+        {
+            var clock = new MockClock();
+            var count = 0;
+
+            using IDisposable timer = clock.StartTimer(null, TimeSpan.FromSeconds(5), Timeout.InfiniteTimeSpan, _ => count++);
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(4));
+            Assert.Equal(0, count);
+
+            // Advancing well past the due time still fires a one-shot timer exactly once.
+            clock.AdvanceBy(TimeSpan.FromSeconds(10));
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void StartTimer_ZeroInterval_IsOneShot()
+        {
+            var clock = new MockClock();
+            var count = 0;
+
+            using IDisposable timer = clock.StartTimer(null, TimeSpan.FromSeconds(1), TimeSpan.Zero, _ => count++);
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(10));
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void StartTimer_ZeroDueTime_FiresImmediately()
+        {
+            var clock = new MockClock();
+            var fired = false;
+
+            // A zero due time is already reached, so the callback fires synchronously during the call.
+            using IDisposable timer = clock.StartTimer(null, TimeSpan.Zero, Timeout.InfiniteTimeSpan, _ => fired = true);
+
+            Assert.True(fired, "Timer with a zero due time did not fire synchronously during StartTimer.");
+        }
+
+        [Fact]
+        public void StartTimer_InfiniteDueTime_NeverFires()
+        {
+            var clock = new MockClock();
+            var fired = false;
+
+            using IDisposable timer = clock.StartTimer(null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan, _ => fired = true);
+
+            clock.AdvanceBy(TimeSpan.FromHours(1));
+
+            Assert.False(fired, "Timer fired despite an infinite due time.");
+        }
+
+        [Fact]
+        public void StartTimer_Periodic_FiresOncePerInterval()
+        {
+            var clock = new MockClock();
+            var count = 0;
+
+            using IDisposable timer = clock.StartTimer(null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), _ => count++);
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(5, count);
+        }
+
+        [Fact]
+        public void StartTimer_Periodic_DueTimeDiffersFromInterval()
+        {
+            var clock = new MockClock();
+            var count = 0;
+
+            // The first tick lands at dueTime (+2s); subsequent ticks follow every interval (+3s, +4s, +5s),
+            // measured from each claimed due instant rather than from when the callback ran.
+            using IDisposable timer = clock.StartTimer(null, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), _ => count++);
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(4, count);
+        }
+
+        [Fact]
+        public void StartTimer_StatePassedToCallback()
+        {
+            var clock = new MockClock();
+            var expectedState = new object();
+            object? actualState = null;
+
+            using IDisposable timer = clock.StartTimer(expectedState, TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan, state => actualState = state);
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(1));
+
+            Assert.Same(expectedState, actualState);
+        }
+    }
+}

--- a/src/WindyCliffs.Clock.Tests/MockTimerTests.cs
+++ b/src/WindyCliffs.Clock.Tests/MockTimerTests.cs
@@ -1,0 +1,187 @@
+namespace WindyCliffs.Clock.Tests
+{
+    using System;
+    using System.Threading;
+    using Xunit;
+
+    public class MockTimerTests
+    {
+        // milliseconds for an infinite (one-shot / never) timeout, matching Timeout.InfiniteTimeSpan.
+        private const long Infinite = -1;
+
+        private static long Ms(double seconds) => (long)TimeSpan.FromSeconds(seconds).TotalMilliseconds;
+
+        [Fact]
+        public void FiresImmediatelyWhenDueTimeIsZero()
+        {
+            var clock = new MockClock();
+            var fired = false;
+
+            // A zero due time is already reached, so the constructor's check fires the callback synchronously.
+            using var timer = new MockTimer(clock, null, 0, Infinite, _ => fired = true);
+
+            Assert.True(fired);
+        }
+
+        [Fact]
+        public void DoesNotFireBeforeDueTime()
+        {
+            var clock = new MockClock();
+            var fired = false;
+
+            using var timer = new MockTimer(clock, null, Ms(5), Infinite, _ => fired = true);
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(4));
+
+            Assert.False(fired);
+        }
+
+        [Fact]
+        public void CatchUpFiringIsIndependentOfAdvancementStep()
+        {
+            var clock = new MockClock();
+            var count = 0;
+
+            using var timer = new MockTimer(clock, null, Ms(1), Ms(1), _ => count++);
+
+            // A single advance whose step is larger than the period must still fire once per elapsed
+            // period (catch-up), so behaviour does not depend on the advancement granularity.
+            clock.AdvanceBy(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
+
+            Assert.Equal(5, count);
+        }
+
+        [Fact]
+        public void DisposeBeforeDueTimePreventsFiring()
+        {
+            var clock = new MockClock();
+            var fired = false;
+
+            var timer = new MockTimer(clock, null, Ms(5), Infinite, _ => fired = true);
+            timer.Dispose();
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(5));
+
+            Assert.False(fired, "Timer fired after being disposed.");
+        }
+
+        [Fact]
+        public void DisposeMidRunStopsFurtherCallbacks()
+        {
+            var clock = new MockClock();
+            var count = 0;
+
+            using var timer = new MockTimer(clock, null, Ms(1), Ms(1), _ => count++);
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(3));
+            Assert.Equal(3, count);
+
+            timer.Dispose();
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(3));
+            Assert.Equal(3, count);
+        }
+
+        [Fact]
+        public void DisposeIsIdempotent()
+        {
+            var clock = new MockClock();
+
+            var timer = new MockTimer(clock, null, Ms(5), Infinite, _ => { });
+
+            timer.Dispose();
+
+            var exception = Record.Exception(() => timer.Dispose());
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DisposeAfterFiringIsSafe()
+        {
+            var clock = new MockClock();
+
+            var timer = new MockTimer(clock, null, Ms(1), Infinite, _ => { });
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(1));
+
+            var exception = Record.Exception(() => timer.Dispose());
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DisposeFromWithinCallbackIsSafe()
+        {
+            var clock = new MockClock();
+            var count = 0;
+            MockTimer? timer = null;
+
+            // The callback runs outside the lock, so disposing the timer from within it must not
+            // deadlock and must stop any further periodic callbacks.
+            timer = new MockTimer(clock, null, Ms(1), Ms(1), _ =>
+            {
+                count++;
+                timer!.Dispose();
+            });
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void CallbackAdvancingClockDoesNotDoubleFire()
+        {
+            var clock = new MockClock();
+            var count = 0;
+
+            using var timer = new MockTimer(clock, null, Ms(1), Ms(1), _ =>
+            {
+                count++;
+
+                // Re-entrant advancement from the callback: each tick must still be claimed exactly once
+                // and the recursion must stay bounded. Advance only while there is more ground to cover.
+                if (clock.UtcNow < MockClock.DefaultStartTime + TimeSpan.FromSeconds(3))
+                {
+                    clock.AdvanceBy(TimeSpan.FromSeconds(1));
+                }
+            });
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(1));
+
+            // Ticks at +1s, +2s and +3s each fire once: no tick is fired twice despite the re-entrancy.
+            Assert.Equal(3, count);
+        }
+
+        [Fact]
+        public void TimersAreIsolatedAcrossClocks()
+        {
+            var clockA = new MockClock();
+            var clockB = new MockClock();
+            var fired = false;
+
+            using var timer = new MockTimer(clockA, null, Ms(1), Infinite, _ => fired = true);
+
+            clockB.AdvanceBy(TimeSpan.FromSeconds(10));
+
+            Assert.False(fired, "A timer fired when an unrelated clock advanced.");
+        }
+
+        [Fact]
+        public void MultipleTimersOnOneClockFireIndependently()
+        {
+            var clock = new MockClock();
+            var firstCount = 0;
+            var secondCount = 0;
+
+            using var first = new MockTimer(clock, null, Ms(1), Ms(1), _ => firstCount++);
+            using var second = new MockTimer(clock, null, Ms(2), Ms(2), _ => secondCount++);
+
+            clock.AdvanceBy(TimeSpan.FromSeconds(4));
+
+            Assert.Equal(4, firstCount);  // +1, +2, +3, +4
+            Assert.Equal(2, secondCount); // +2, +4
+        }
+    }
+}

--- a/src/WindyCliffs.Clock.Tests/MockTimerTests.cs
+++ b/src/WindyCliffs.Clock.Tests/MockTimerTests.cs
@@ -6,10 +6,10 @@ namespace WindyCliffs.Clock.Tests
 
     public class MockTimerTests
     {
-        // milliseconds for an infinite (one-shot / never) timeout, matching Timeout.InfiniteTimeSpan.
-        private const long Infinite = -1;
+        // An infinite (one-shot / never) timeout.
+        private static readonly TimeSpan Infinite = Timeout.InfiniteTimeSpan;
 
-        private static long Ms(double seconds) => (long)TimeSpan.FromSeconds(seconds).TotalMilliseconds;
+        private static TimeSpan Sec(double seconds) => TimeSpan.FromSeconds(seconds);
 
         [Fact]
         public void FiresImmediatelyWhenDueTimeIsZero()
@@ -18,7 +18,7 @@ namespace WindyCliffs.Clock.Tests
             var fired = false;
 
             // A zero due time is already reached, so the constructor's check fires the callback synchronously.
-            using var timer = new MockTimer(clock, null, 0, Infinite, _ => fired = true);
+            using var timer = new MockTimer(clock, null, TimeSpan.Zero, Infinite, _ => fired = true);
 
             Assert.True(fired);
         }
@@ -29,7 +29,7 @@ namespace WindyCliffs.Clock.Tests
             var clock = new MockClock();
             var fired = false;
 
-            using var timer = new MockTimer(clock, null, Ms(5), Infinite, _ => fired = true);
+            using var timer = new MockTimer(clock, null, Sec(5), Infinite, _ => fired = true);
 
             clock.AdvanceBy(TimeSpan.FromSeconds(4));
 
@@ -42,7 +42,7 @@ namespace WindyCliffs.Clock.Tests
             var clock = new MockClock();
             var count = 0;
 
-            using var timer = new MockTimer(clock, null, Ms(1), Ms(1), _ => count++);
+            using var timer = new MockTimer(clock, null, Sec(1), Sec(1), _ => count++);
 
             // A single advance whose step is larger than the period must still fire once per elapsed
             // period (catch-up), so behaviour does not depend on the advancement granularity.
@@ -57,7 +57,7 @@ namespace WindyCliffs.Clock.Tests
             var clock = new MockClock();
             var fired = false;
 
-            var timer = new MockTimer(clock, null, Ms(5), Infinite, _ => fired = true);
+            var timer = new MockTimer(clock, null, Sec(5), Infinite, _ => fired = true);
             timer.Dispose();
 
             clock.AdvanceBy(TimeSpan.FromSeconds(5));
@@ -71,7 +71,7 @@ namespace WindyCliffs.Clock.Tests
             var clock = new MockClock();
             var count = 0;
 
-            using var timer = new MockTimer(clock, null, Ms(1), Ms(1), _ => count++);
+            using var timer = new MockTimer(clock, null, Sec(1), Sec(1), _ => count++);
 
             clock.AdvanceBy(TimeSpan.FromSeconds(3));
             Assert.Equal(3, count);
@@ -87,7 +87,7 @@ namespace WindyCliffs.Clock.Tests
         {
             var clock = new MockClock();
 
-            var timer = new MockTimer(clock, null, Ms(5), Infinite, _ => { });
+            var timer = new MockTimer(clock, null, Sec(5), Infinite, _ => { });
 
             timer.Dispose();
 
@@ -101,7 +101,7 @@ namespace WindyCliffs.Clock.Tests
         {
             var clock = new MockClock();
 
-            var timer = new MockTimer(clock, null, Ms(1), Infinite, _ => { });
+            var timer = new MockTimer(clock, null, Sec(1), Infinite, _ => { });
 
             clock.AdvanceBy(TimeSpan.FromSeconds(1));
 
@@ -119,7 +119,7 @@ namespace WindyCliffs.Clock.Tests
 
             // The callback runs outside the lock, so disposing the timer from within it must not
             // deadlock and must stop any further periodic callbacks.
-            timer = new MockTimer(clock, null, Ms(1), Ms(1), _ =>
+            timer = new MockTimer(clock, null, Sec(1), Sec(1), _ =>
             {
                 count++;
                 timer!.Dispose();
@@ -136,7 +136,7 @@ namespace WindyCliffs.Clock.Tests
             var clock = new MockClock();
             var count = 0;
 
-            using var timer = new MockTimer(clock, null, Ms(1), Ms(1), _ =>
+            using var timer = new MockTimer(clock, null, Sec(1), Sec(1), _ =>
             {
                 count++;
 
@@ -161,7 +161,7 @@ namespace WindyCliffs.Clock.Tests
             var clockB = new MockClock();
             var fired = false;
 
-            using var timer = new MockTimer(clockA, null, Ms(1), Infinite, _ => fired = true);
+            using var timer = new MockTimer(clockA, null, Sec(1), Infinite, _ => fired = true);
 
             clockB.AdvanceBy(TimeSpan.FromSeconds(10));
 
@@ -175,8 +175,8 @@ namespace WindyCliffs.Clock.Tests
             var firstCount = 0;
             var secondCount = 0;
 
-            using var first = new MockTimer(clock, null, Ms(1), Ms(1), _ => firstCount++);
-            using var second = new MockTimer(clock, null, Ms(2), Ms(2), _ => secondCount++);
+            using var first = new MockTimer(clock, null, Sec(1), Sec(1), _ => firstCount++);
+            using var second = new MockTimer(clock, null, Sec(2), Sec(2), _ => secondCount++);
 
             clock.AdvanceBy(TimeSpan.FromSeconds(4));
 

--- a/src/WindyCliffs.Clock.Tests/SystemClockTests.cs
+++ b/src/WindyCliffs.Clock.Tests/SystemClockTests.cs
@@ -169,5 +169,116 @@ namespace WindyCliffs.Clock.Tests
             Assert.Equal(0, signaled);
             Assert.True(cts.IsCancellationRequested);
         }
+
+        [Fact]
+        public void StartTimer_NullCallback()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => SystemClock.Instance.StartTimer(null, TimeSpan.FromMilliseconds(1), Timeout.InfiniteTimeSpan, null!));
+        }
+
+        [Theory]
+        [InlineData(-2)]
+        [InlineData(4294967295)]
+        public void StartTimer_DueTimeOutOfRange(long dueMilliseconds)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => SystemClock.Instance.StartTimer(null, TimeSpan.FromMilliseconds(dueMilliseconds), Timeout.InfiniteTimeSpan, _ => { }));
+        }
+
+        [Theory]
+        [InlineData(-2)]
+        [InlineData(4294967295)]
+        public void StartTimer_IntervalOutOfRange(long intervalMilliseconds)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => SystemClock.Instance.StartTimer(null, TimeSpan.Zero, TimeSpan.FromMilliseconds(intervalMilliseconds), _ => { }));
+        }
+
+        [Fact]
+        public void StartTimer_ReturnsDisposable()
+        {
+            using IDisposable timer = SystemClock.Instance.StartTimer(null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan, _ => { });
+
+            Assert.NotNull(timer);
+        }
+
+        [Fact]
+        public void StartTimer_FiresAfterDueTime()
+        {
+            using var fired = new ManualResetEventSlim(false);
+            var expectedState = new object();
+            object? actualState = null;
+
+            using IDisposable timer = SystemClock.Instance.StartTimer(
+                expectedState,
+                TimeSpan.FromMilliseconds(50),
+                Timeout.InfiniteTimeSpan,
+                state =>
+                {
+                    actualState = state;
+                    fired.Set();
+                });
+
+            Assert.True(fired.Wait(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken), "Timer never fired.");
+            Assert.Same(expectedState, actualState);
+        }
+
+        [Fact]
+        public void StartTimer_Periodic_FiresRepeatedly()
+        {
+            using var firedTwice = new CountdownEvent(2);
+
+            using IDisposable timer = SystemClock.Instance.StartTimer(
+                null,
+                TimeSpan.FromMilliseconds(20),
+                TimeSpan.FromMilliseconds(20),
+                _ =>
+                {
+                    if (!firedTwice.IsSet)
+                    {
+                        firedTwice.Signal();
+                    }
+                });
+
+            Assert.True(firedTwice.Wait(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken), "Timer did not fire repeatedly.");
+        }
+
+        [Fact]
+        public void StartTimer_Dispose_StopsCallbacks()
+        {
+            var count = 0;
+
+            IDisposable timer = SystemClock.Instance.StartTimer(
+                null,
+                TimeSpan.FromMilliseconds(20),
+                TimeSpan.FromMilliseconds(20),
+                _ => Interlocked.Increment(ref count));
+
+            timer.Dispose();
+
+            int afterDispose = Volatile.Read(ref count);
+
+            // Wait well past several would-be periods; no further callbacks must run after Dispose.
+            // 500 ms is well beyond several 20 ms periods, giving a loaded CI machine slack so the
+            // negative assertion does not produce a false positive on slow scheduling.
+            Assert.False(
+                SpinWait.SpinUntil(() => Volatile.Read(ref count) > afterDispose, TimeSpan.FromMilliseconds(500)),
+                "Callback ran after the timer was disposed.");
+        }
+
+        [Fact]
+        public void StartTimer_InfiniteDueTime_NeverFires()
+        {
+            using var fired = new ManualResetEventSlim(false);
+
+            using IDisposable timer = SystemClock.Instance.StartTimer(
+                null,
+                Timeout.InfiniteTimeSpan,
+                Timeout.InfiniteTimeSpan,
+                _ => fired.Set());
+
+            Assert.False(fired.Wait(TimeSpan.FromMilliseconds(200), TestContext.Current.CancellationToken), "Timer fired despite an infinite due time.");
+        }
     }
 }

--- a/src/WindyCliffs.Clock/IClock.cs
+++ b/src/WindyCliffs.Clock/IClock.cs
@@ -91,5 +91,66 @@
         /// When <paramref name="source"/> has already been disposed.
         /// </exception>
         void CancelAfter(CancellationTokenSource source, TimeSpan timeout);
+
+        /// <summary>
+        /// Starts a timer that invokes <paramref name="callback"/> after <paramref name="dueTime"/>
+        /// elapses and, for a positive <paramref name="interval"/>, repeatedly every
+        /// <paramref name="interval"/> thereafter.
+        /// Replacement for the <see cref="System.Threading.Timer"/> constructor.
+        /// </summary>
+        /// <param name="state">
+        /// An object passed to <paramref name="callback"/> on every invocation, or
+        /// <see langword="null"/>.
+        /// </param>
+        /// <param name="dueTime">
+        /// The amount of time to wait before <paramref name="callback"/> is invoked for the first
+        /// time. <see cref="TimeSpan.Zero"/> invokes <paramref name="callback"/> immediately;
+        /// <see cref="Timeout.InfiniteTimeSpan"/> prevents the first invocation, so the timer never
+        /// fires until it is restarted (which this abstraction does not support) — it can only be
+        /// disposed.
+        /// </param>
+        /// <param name="interval">
+        /// The amount of time between invocations of <paramref name="callback"/>. A value of
+        /// <see cref="TimeSpan.Zero"/> or <see cref="Timeout.InfiniteTimeSpan"/> disables periodic
+        /// signalling, so <paramref name="callback"/> is invoked only once (when
+        /// <paramref name="dueTime"/> elapses). Any positive value makes the timer periodic.
+        /// </param>
+        /// <param name="callback">The delegate invoked when the timer fires.</param>
+        /// <returns>
+        /// An <see cref="IDisposable"/> that stops the timer when disposed. Disposing it prevents
+        /// any <em>future</em> invocations and is idempotent and safe to call after the timer has
+        /// fired (including from within <paramref name="callback"/> itself); a callback already in
+        /// progress when <see cref="IDisposable.Dispose"/> is called may still run to completion,
+        /// mirroring <see cref="System.Threading.Timer.Dispose()"/>. The return type is intentionally
+        /// <see cref="IDisposable"/> only (not <c>IAsyncDisposable</c>), matching the library's
+        /// <c>netstandard2.0</c> target.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="dueTime"/> and <paramref name="interval"/> are validated exactly as the
+        /// <see cref="System.Threading.Timer"/> constructor validates them: each is converted to
+        /// whole milliseconds (truncating any sub-millisecond remainder) and must be between
+        /// <c>-1</c> (<see cref="Timeout.InfiniteTimeSpan"/>) and <c>4294967294</c> inclusive.
+        /// </para>
+        /// <para>
+        /// <see cref="MockClock"/> drives the timer from its <see cref="MockClock.AdvanceBy(TimeSpan)"/> /
+        /// <see cref="MockClock.AdvanceTo(DateTimeOffset)"/> time-advancement rather than wall-clock
+        /// time, with three deliberate differences from a real <see cref="System.Threading.Timer"/>:
+        /// the callback runs <em>synchronously</em> on the thread that advances the clock (or the
+        /// constructing thread, for an already-due timer) rather than on a thread-pool thread; when
+        /// the clock advances past several intervals at once the callback fires once per elapsed
+        /// interval (catch-up), so behaviour is independent of the advancement step; and an exception
+        /// thrown by the callback propagates to the advancing caller (a real timer's thread-pool
+        /// callback exception would crash the process).
+        /// </para>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// When <paramref name="callback"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// When the whole-millisecond value of <paramref name="dueTime"/> or
+        /// <paramref name="interval"/> is less than <c>-1</c> or greater than <c>4294967294</c>.
+        /// </exception>
+        IDisposable StartTimer(object? state, TimeSpan dueTime, TimeSpan interval, TimerCallback callback);
     }
 }

--- a/src/WindyCliffs.Clock/IClock.cs
+++ b/src/WindyCliffs.Clock/IClock.cs
@@ -126,23 +126,10 @@
         /// <c>netstandard2.0</c> target.
         /// </returns>
         /// <remarks>
-        /// <para>
         /// <paramref name="dueTime"/> and <paramref name="interval"/> are validated exactly as the
         /// <see cref="System.Threading.Timer"/> constructor validates them: each is converted to
         /// whole milliseconds (truncating any sub-millisecond remainder) and must be between
         /// <c>-1</c> (<see cref="Timeout.InfiniteTimeSpan"/>) and <c>4294967294</c> inclusive.
-        /// </para>
-        /// <para>
-        /// <see cref="MockClock"/> drives the timer from its <see cref="MockClock.AdvanceBy(TimeSpan)"/> /
-        /// <see cref="MockClock.AdvanceTo(DateTimeOffset)"/> time-advancement rather than wall-clock
-        /// time, with three deliberate differences from a real <see cref="System.Threading.Timer"/>:
-        /// the callback runs <em>synchronously</em> on the thread that advances the clock (or the
-        /// constructing thread, for an already-due timer) rather than on a thread-pool thread; when
-        /// the clock advances past several intervals at once the callback fires once per elapsed
-        /// interval (catch-up), so behaviour is independent of the advancement step; and an exception
-        /// thrown by the callback propagates to the advancing caller (a real timer's thread-pool
-        /// callback exception would crash the process).
-        /// </para>
         /// </remarks>
         /// <exception cref="ArgumentNullException">
         /// When <paramref name="callback"/> is <see langword="null"/>.

--- a/src/WindyCliffs.Clock/MockClock.cs
+++ b/src/WindyCliffs.Clock/MockClock.cs
@@ -17,6 +17,11 @@
 
         private static readonly TimeSpan DefaultAdvancementStep = TimeSpan.FromSeconds(1);
 
+        // The largest timeout System.Threading.Timer accepts, in milliseconds (0xFFFFFFFE). This is a
+        // fixed constant across .NET Framework and modern .NET, so MockClock and SystemClock reject the
+        // same out-of-range values on every target runtime.
+        private const long MaxSupportedTimeoutMilliseconds = 0xFFFFFFFE;
+
         private long utcNow = DefaultStartTime.ToFileTime();
 
         private TimeSpan advancementStep = DefaultAdvancementStep;
@@ -157,6 +162,34 @@
             }
 
             this.scheduledCancellations.AddOrReplace(source, timeout);
+        }
+
+        /// <inheritdoc />
+        public IDisposable StartTimer(object? state, TimeSpan dueTime, TimeSpan interval, TimerCallback callback)
+        {
+            // Replicate the System.Threading.Timer constructor's argument handling exactly: it truncates
+            // each TimeSpan to whole milliseconds, validates the ranges (before the null-callback check),
+            // then verifies the callback. Truncating here too keeps scheduling faithful — a sub-millisecond
+            // due time collapses to zero and fires immediately, as a real Timer does.
+            long dueMilliseconds = (long)dueTime.TotalMilliseconds;
+            long intervalMilliseconds = (long)interval.TotalMilliseconds;
+
+            if (dueMilliseconds < -1 || dueMilliseconds > MaxSupportedTimeoutMilliseconds)
+            {
+                throw new ArgumentOutOfRangeException(nameof(dueTime));
+            }
+
+            if (intervalMilliseconds < -1 || intervalMilliseconds > MaxSupportedTimeoutMilliseconds)
+            {
+                throw new ArgumentOutOfRangeException(nameof(interval));
+            }
+
+            if (callback is null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+
+            return new MockTimer(this, state, dueMilliseconds, intervalMilliseconds, callback);
         }
 
         /// <summary>

--- a/src/WindyCliffs.Clock/MockClock.cs
+++ b/src/WindyCliffs.Clock/MockClock.cs
@@ -17,11 +17,6 @@
 
         private static readonly TimeSpan DefaultAdvancementStep = TimeSpan.FromSeconds(1);
 
-        // The largest timeout System.Threading.Timer accepts, in milliseconds (0xFFFFFFFE). This is a
-        // fixed constant across .NET Framework and modern .NET, so MockClock and SystemClock reject the
-        // same out-of-range values on every target runtime.
-        private const long MaxSupportedTimeoutMilliseconds = 0xFFFFFFFE;
-
         private long utcNow = DefaultStartTime.ToFileTime();
 
         private TimeSpan advancementStep = DefaultAdvancementStep;
@@ -166,31 +161,9 @@
 
         /// <inheritdoc />
         public IDisposable StartTimer(object? state, TimeSpan dueTime, TimeSpan interval, TimerCallback callback)
-        {
-            // Replicate the System.Threading.Timer constructor's argument handling exactly: it truncates
-            // each TimeSpan to whole milliseconds, validates the ranges (before the null-callback check),
-            // then verifies the callback. Truncating here too keeps scheduling faithful — a sub-millisecond
-            // due time collapses to zero and fires immediately, as a real Timer does.
-            long dueMilliseconds = (long)dueTime.TotalMilliseconds;
-            long intervalMilliseconds = (long)interval.TotalMilliseconds;
-
-            if (dueMilliseconds < -1 || dueMilliseconds > MaxSupportedTimeoutMilliseconds)
-            {
-                throw new ArgumentOutOfRangeException(nameof(dueTime));
-            }
-
-            if (intervalMilliseconds < -1 || intervalMilliseconds > MaxSupportedTimeoutMilliseconds)
-            {
-                throw new ArgumentOutOfRangeException(nameof(interval));
-            }
-
-            if (callback is null)
-            {
-                throw new ArgumentNullException(nameof(callback));
-            }
-
-            return new MockTimer(this, state, dueMilliseconds, intervalMilliseconds, callback);
-        }
+            // MockTimer validates its arguments (mirroring the System.Threading.Timer constructor) and
+            // schedules itself against this clock's Changed event.
+            => new MockTimer(this, state, dueTime, interval, callback);
 
         /// <summary>
         /// Gets or sets the advancement step used by <see cref="AdvanceBy(TimeSpan)"/> and

--- a/src/WindyCliffs.Clock/MockTimer.cs
+++ b/src/WindyCliffs.Clock/MockTimer.cs
@@ -1,0 +1,108 @@
+namespace WindyCliffs.Clock
+{
+    using System;
+    using System.Threading;
+
+    /// <summary>
+    /// A timer driven by a <see cref="MockClock"/> rather than wall-clock time. Like
+    /// <see cref="ScheduledAction"/> it subscribes to <see cref="MockClock.Changed"/>, but instead of
+    /// firing once and disposing itself it re-arms after each invocation so it can mimic a periodic
+    /// <see cref="System.Threading.Timer"/>. Disposing it unsubscribes and stops further callbacks.
+    /// </summary>
+    /// <remarks>
+    /// Unlike a real <see cref="System.Threading.Timer"/>, the callback runs synchronously on the
+    /// thread advancing the clock (or the constructing thread, for an already-due timer); when the
+    /// clock advances past several intervals at once the callback fires once per elapsed interval; and
+    /// an exception thrown by the callback propagates to the advancing caller. The owner
+    /// (<see cref="MockClock.StartTimer"/>) is responsible for validating the arguments and passing the
+    /// already-truncated whole-millisecond <paramref name="dueMilliseconds"/> / <paramref name="periodMilliseconds"/>.
+    /// </remarks>
+    internal sealed class MockTimer : IDisposable
+    {
+        private readonly MockClock clock;
+
+        private readonly object? state;
+
+        private readonly TimerCallback callback;
+
+        private readonly bool isPeriodic;
+
+        private readonly TimeSpan period;
+
+        private readonly object syncRoot = new object();
+
+        // Read and written only under syncRoot, so the lock already provides the necessary memory
+        // barrier — unlike ScheduledAction, there is no pre-lock fast-path read that would need volatile.
+        private bool isDisposed = false;
+
+        // The next instant at or after which the callback fires, or null when the timer will never fire
+        // again (an infinite due time at construction, or a one-shot timer that has already fired).
+        private DateTimeOffset? nextDueTime;
+
+        public MockTimer(MockClock clock, object? state, long dueMilliseconds, long periodMilliseconds, TimerCallback callback)
+        {
+            this.clock = clock;
+            this.state = state;
+            this.callback = callback;
+
+            // A positive period repeats; both zero and -1 (infinite) milliseconds make the timer
+            // one-shot, matching System.Threading.Timer. period is left unused when !isPeriodic.
+            this.isPeriodic = periodMilliseconds > 0;
+            this.period = TimeSpan.FromMilliseconds(periodMilliseconds);
+
+            // An infinite due time (-1 ms) never fires: compute no target rather than offsetting UtcNow,
+            // which would otherwise move the deadline into the past and fire immediately.
+            this.nextDueTime = dueMilliseconds < 0
+                ? (DateTimeOffset?)null
+                : this.clock.UtcNow + TimeSpan.FromMilliseconds(dueMilliseconds);
+
+            this.clock.Changed += this.ClockChanged;
+
+            // Fire synchronously when the due time is already reached (e.g. a zero due time), matching
+            // ScheduledAction's construction-time check.
+            this.ClockChanged(this.clock, this.clock.UtcNow);
+        }
+
+        public void Dispose()
+        {
+            lock (this.syncRoot)
+            {
+                this.isDisposed = true;
+                this.clock.Changed -= this.ClockChanged;
+            }
+        }
+
+        private void ClockChanged(MockClock clock, DateTimeOffset utcNow)
+        {
+            while (true)
+            {
+                DateTimeOffset due;
+
+                lock (this.syncRoot)
+                {
+                    if (this.isDisposed || !this.nextDueTime.HasValue)
+                    {
+                        return;
+                    }
+
+                    due = this.nextDueTime.Value;
+
+                    if (utcNow < due)
+                    {
+                        return;
+                    }
+
+                    // Claim this tick under the lock by advancing the schedule before releasing it, so a
+                    // concurrent advance (or a re-entrant one raised by the callback) cannot re-fire the
+                    // same tick. A one-shot timer becomes inert (null) after its single fire.
+                    this.nextDueTime = this.isPeriodic ? due + this.period : (DateTimeOffset?)null;
+                }
+
+                // Invoke outside the lock: the callback is arbitrary user code that may advance the
+                // clock (re-entering this handler) or dispose the timer, neither of which must contend
+                // for syncRoot while it is held.
+                this.callback(this.state);
+            }
+        }
+    }
+}

--- a/src/WindyCliffs.Clock/MockTimer.cs
+++ b/src/WindyCliffs.Clock/MockTimer.cs
@@ -44,10 +44,11 @@ namespace WindyCliffs.Clock
 
         public MockTimer(MockClock clock, object? state, TimeSpan dueTime, TimeSpan interval, TimerCallback callback)
         {
-            // Validate exactly as the System.Threading.Timer constructor does: truncate each TimeSpan to
-            // whole milliseconds, range-check both (before the null-callback check), then verify the
-            // callback. Truncating keeps scheduling faithful — a sub-millisecond due time collapses to
-            // zero and fires immediately, as a real Timer does.
+            // Range-validate exactly as the System.Threading.Timer constructor does: it converts each
+            // TimeSpan to whole milliseconds and requires the result in [-1, MaxSupportedTimeout],
+            // checking the ranges before the null-callback check. Milliseconds are needed only here and
+            // for the infinite/periodic classification just below, because Timer quantises both to whole
+            // milliseconds; everything else works in TimeSpan.
             long dueMilliseconds = (long)dueTime.TotalMilliseconds;
             long intervalMilliseconds = (long)interval.TotalMilliseconds;
 
@@ -70,16 +71,16 @@ namespace WindyCliffs.Clock
             this.state = state;
             this.callback = callback;
 
-            // A positive period repeats; both zero and -1 (infinite) milliseconds make the timer
-            // one-shot, matching System.Threading.Timer. period is left unused when !isPeriodic.
+            // A positive interval repeats; both a zero and an infinite interval make the timer one-shot,
+            // matching System.Threading.Timer. period is left unused when !isPeriodic.
             this.isPeriodic = intervalMilliseconds > 0;
-            this.period = TimeSpan.FromMilliseconds(intervalMilliseconds);
+            this.period = interval;
 
-            // An infinite due time (-1 ms) never fires: compute no target rather than offsetting UtcNow,
-            // which would otherwise move the deadline into the past and fire immediately.
+            // An infinite due time (-1 ms after truncation) never fires: store no target rather than
+            // offsetting UtcNow, which would otherwise move the deadline into the past and fire immediately.
             this.nextDueTime = dueMilliseconds < 0
                 ? (DateTimeOffset?)null
-                : this.clock.UtcNow + TimeSpan.FromMilliseconds(dueMilliseconds);
+                : this.clock.UtcNow + dueTime;
 
             // A timer with no due time can never fire, so there is nothing to subscribe to; it can only be
             // disposed. Otherwise subscribe and check the current time so an already-due timer (e.g. a

--- a/src/WindyCliffs.Clock/MockTimer.cs
+++ b/src/WindyCliffs.Clock/MockTimer.cs
@@ -13,12 +13,15 @@ namespace WindyCliffs.Clock
     /// Unlike a real <see cref="System.Threading.Timer"/>, the callback runs synchronously on the
     /// thread advancing the clock (or the constructing thread, for an already-due timer); when the
     /// clock advances past several intervals at once the callback fires once per elapsed interval; and
-    /// an exception thrown by the callback propagates to the advancing caller. The owner
-    /// (<see cref="MockClock.StartTimer"/>) is responsible for validating the arguments and passing the
-    /// already-truncated whole-millisecond <paramref name="dueMilliseconds"/> / <paramref name="periodMilliseconds"/>.
+    /// an exception thrown by the callback propagates to the advancing caller.
     /// </remarks>
     internal sealed class MockTimer : IDisposable
     {
+        // The largest timeout System.Threading.Timer accepts, in milliseconds (0xFFFFFFFE). This is a
+        // fixed constant across .NET Framework and modern .NET, so MockClock and SystemClock reject the
+        // same out-of-range values on every target runtime.
+        private const long MaxSupportedTimeoutMilliseconds = 0xFFFFFFFE;
+
         private readonly MockClock clock;
 
         private readonly object? state;
@@ -39,16 +42,38 @@ namespace WindyCliffs.Clock
         // again (an infinite due time at construction, or a one-shot timer that has already fired).
         private DateTimeOffset? nextDueTime;
 
-        public MockTimer(MockClock clock, object? state, long dueMilliseconds, long periodMilliseconds, TimerCallback callback)
+        public MockTimer(MockClock clock, object? state, TimeSpan dueTime, TimeSpan interval, TimerCallback callback)
         {
+            // Validate exactly as the System.Threading.Timer constructor does: truncate each TimeSpan to
+            // whole milliseconds, range-check both (before the null-callback check), then verify the
+            // callback. Truncating keeps scheduling faithful — a sub-millisecond due time collapses to
+            // zero and fires immediately, as a real Timer does.
+            long dueMilliseconds = (long)dueTime.TotalMilliseconds;
+            long intervalMilliseconds = (long)interval.TotalMilliseconds;
+
+            if (dueMilliseconds < -1 || dueMilliseconds > MaxSupportedTimeoutMilliseconds)
+            {
+                throw new ArgumentOutOfRangeException(nameof(dueTime));
+            }
+
+            if (intervalMilliseconds < -1 || intervalMilliseconds > MaxSupportedTimeoutMilliseconds)
+            {
+                throw new ArgumentOutOfRangeException(nameof(interval));
+            }
+
+            if (callback is null)
+            {
+                throw new ArgumentNullException(nameof(callback));
+            }
+
             this.clock = clock;
             this.state = state;
             this.callback = callback;
 
             // A positive period repeats; both zero and -1 (infinite) milliseconds make the timer
             // one-shot, matching System.Threading.Timer. period is left unused when !isPeriodic.
-            this.isPeriodic = periodMilliseconds > 0;
-            this.period = TimeSpan.FromMilliseconds(periodMilliseconds);
+            this.isPeriodic = intervalMilliseconds > 0;
+            this.period = TimeSpan.FromMilliseconds(intervalMilliseconds);
 
             // An infinite due time (-1 ms) never fires: compute no target rather than offsetting UtcNow,
             // which would otherwise move the deadline into the past and fire immediately.
@@ -56,11 +81,14 @@ namespace WindyCliffs.Clock
                 ? (DateTimeOffset?)null
                 : this.clock.UtcNow + TimeSpan.FromMilliseconds(dueMilliseconds);
 
-            this.clock.Changed += this.ClockChanged;
-
-            // Fire synchronously when the due time is already reached (e.g. a zero due time), matching
-            // ScheduledAction's construction-time check.
-            this.ClockChanged(this.clock, this.clock.UtcNow);
+            // A timer with no due time can never fire, so there is nothing to subscribe to; it can only be
+            // disposed. Otherwise subscribe and check the current time so an already-due timer (e.g. a
+            // zero due time) fires synchronously, matching ScheduledAction's construction-time check.
+            if (this.nextDueTime.HasValue)
+            {
+                this.clock.Changed += this.ClockChanged;
+                this.ClockChanged(this.clock, this.clock.UtcNow);
+            }
         }
 
         public void Dispose()
@@ -96,6 +124,13 @@ namespace WindyCliffs.Clock
                     // concurrent advance (or a re-entrant one raised by the callback) cannot re-fire the
                     // same tick. A one-shot timer becomes inert (null) after its single fire.
                     this.nextDueTime = this.isPeriodic ? due + this.period : (DateTimeOffset?)null;
+
+                    // Once the timer can never fire again, stop listening so it does not linger on the
+                    // clock's Changed list for the remainder of the clock's life.
+                    if (!this.nextDueTime.HasValue)
+                    {
+                        this.clock.Changed -= this.ClockChanged;
+                    }
                 }
 
                 // Invoke outside the lock: the callback is arbitrary user code that may advance the

--- a/src/WindyCliffs.Clock/README.md
+++ b/src/WindyCliffs.Clock/README.md
@@ -57,10 +57,12 @@ Assert.True(session.HasExpired(clock.UtcNow));
 | `Sleep(timeout)` | Blocks the caller. Replacement for `Thread.Sleep`. |
 | `TaskDelay(timeout, cancellationToken)` | Awaitable, cancellable delay. Replacement for `Task.Delay`. |
 | `CancelAfter(source, timeout)` | Cancels a `CancellationTokenSource` after the timeout. Replacement for `CancellationTokenSource.CancelAfter`. |
+| `StartTimer(state, dueTime, interval, callback)` | Starts a one-shot or periodic timer. Replacement for the `System.Threading.Timer` constructor. |
 
-With `MockClock`, `Sleep`, `TaskDelay`, and `CancelAfter` are all driven by
-advancing the clock (`AdvanceBy`/`AdvanceTo`) rather than by real elapsed time,
-so time-dependent code — including `async` code — stays deterministic:
+With `MockClock`, `Sleep`, `TaskDelay`, `CancelAfter`, and `StartTimer` are all
+driven by advancing the clock (`AdvanceBy`/`AdvanceTo`) rather than by real
+elapsed time, so time-dependent code — including `async` code — stays
+deterministic:
 
 ```csharp
 var clock = new MockClock();

--- a/src/WindyCliffs.Clock/SystemClock.cs
+++ b/src/WindyCliffs.Clock/SystemClock.cs
@@ -38,5 +38,13 @@
 
             source.CancelAfter(timeout);
         }
+
+        /// <inheritdoc />
+        public IDisposable StartTimer(object? state, TimeSpan dueTime, TimeSpan interval, TimerCallback callback)
+            // IClock orders the arguments (state, dueTime, interval, callback) for readability; the
+            // Timer constructor orders them (callback, state, dueTime, period). The constructor performs
+            // the null-callback and range validation the IClock contract specifies, and Timer itself is
+            // the returned IDisposable (Dispose stops it — no Change-then-dispose dance is needed).
+            => new Timer(callback, state, dueTime, interval);
     }
 }


### PR DESCRIPTION
## Summary

Adds `IDisposable StartTimer(object? state, TimeSpan dueTime, TimeSpan interval, TimerCallback callback)` to `IClock`, a testable replacement for the `System.Threading.Timer` constructor. Code that schedules one-shot or periodic timers can now be driven deterministically in tests instead of depending on the wall clock.

## Notable changes

- **`SystemClock.StartTimer`** — creates a `System.Threading.Timer(callback, state, dueTime, interval)` and returns it (the timer is itself the `IDisposable`).
- **`MockClock.StartTimer`** — validates arguments *exactly* as the `Timer` constructor does: each `TimeSpan` is truncated to whole milliseconds and the `[-1, 0xFFFFFFFE]` ms ranges are checked before the null-callback check. It then drives a new internal `MockTimer`.
- **`MockTimer`** — a new internal class (deliberately separate from `ScheduledAction`, whose fire-once-then-self-dispose invariant can't be periodic). It subscribes to `MockClock.Changed`, claims each due tick atomically under a lock, invokes the callback *outside* the lock, and loops so a single large advance fires once per elapsed interval (catch-up, step-independent).
- **Documented deviations from a real `Timer`** (for determinism): the callback runs synchronously on the advancing thread; missed intervals are caught up rather than coalesced; callback exceptions propagate to the advancing caller; and an in-flight callback may complete after `Dispose()`.
- **Versioning** — adding an `IClock` member is breaking for third-party implementors, so per the pre-1.0 rule this is a minor bump: `0.4.1` → `0.5.0` (`src/Directory.Build.props`), with a `CHANGELOG.md` entry.
- **Docs** — `IClock` XML docs, the NuGet package README table, `docs/USAGE.md` (new `StartTimer` semantics section), and `docs/ARCHITECTURE.md` (new "How `MockClock.StartTimer` works" section) all updated.

## Testing

- `dotnet build src/repo.slnx -warnaserror` → **Build succeeded, 0 warnings, 0 errors**.
- `dotnet test src/repo.slnx` → **113 passed, 0 failed, 0 skipped** on `net48`, `net8.0`, and `net10.0`.
- New coverage: `SystemClockTests` (real-time fire, periodic, dispose-stops, infinite due time, arg validation, state round-trip), `MockClockTests.StartTimer.cs` (public contract incl. zero/infinite due time, periodic with asymmetric due time/interval, validation parity, state pass-through), and `MockTimerTests.cs` (immediate fire, catch-up step-independence, dispose mid-run/from-callback, re-entrant clock advance, cross-clock isolation, multiple independent timers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)