### PR TITLE
feat: add IClock.TaskWait/TaskWaitAny/TaskWaitAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.6.0]
+
+### Added
+- `IClock.TaskWait(Task, TimeSpan, CancellationToken)`,
+  `IClock.TaskWaitAny(Task[], TimeSpan, CancellationToken)`, and
+  `IClock.TaskWaitAll(Task[], TimeSpan, CancellationToken)` with `SystemClock`
+  (delegate to `Task.Wait` / `Task.WaitAny` / `Task.WaitAll`) and `MockClock`
+  implementations. With `MockClock` the timeout is measured on the managed time
+  scale (it elapses only when the clock is advanced via `AdvanceBy`/`AdvanceTo`),
+  while the wait itself still blocks the calling thread. Return values, cancellation,
+  and faulted-task (`AggregateException`) behaviour match the underlying BCL methods.
+
+### Changed
+- **Breaking:** `IClock` gains three members, so existing third-party implementations
+  must add `TaskWait`, `TaskWaitAny`, and `TaskWaitAll` (default interface members are
+  not an option on the `netstandard2.0` / C# 9 target). Per the pre-1.0 versioning rule
+  this is a minor bump.
+
 ## [0.5.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Assert.True(session.HasExpired(clock.UtcNow));
 ## Documentation
 
 - [Usage](docs/USAGE.md) — detailed API guide (`SystemClock`, `MockClock`,
-  time advancement, `Sleep` and `TaskDelay` semantics, the `Changed` event,
+  time advancement, `Sleep`, `TaskDelay`, `CancelAfter`, `StartTimer`, and
+  `TaskWait`/`TaskWaitAny`/`TaskWaitAll` semantics, the `Changed` event,
   testing patterns).
 - [Architecture](docs/ARCHITECTURE.md) — how the abstraction and the
   `MockClock` time-advancement mechanism are designed.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,6 +17,9 @@ public interface IClock
     Task TaskDelay(TimeSpan timeout, CancellationToken cancellationToken = default);
     void CancelAfter(CancellationTokenSource source, TimeSpan timeout);
     IDisposable StartTimer(object? state, TimeSpan dueTime, TimeSpan interval, TimerCallback callback);
+    bool TaskWait(Task task, TimeSpan timeout, CancellationToken cancellationToken = default);
+    int TaskWaitAny(Task[] tasks, TimeSpan timeout, CancellationToken cancellationToken = default);
+    bool TaskWaitAll(Task[] tasks, TimeSpan timeout, CancellationToken cancellationToken = default);
 }
 ```
 
@@ -40,6 +43,10 @@ stateless singleton exposed through `SystemClock.Instance`:
   `System.Threading.Timer(callback, state, dueTime, interval)` and returns it (the
   timer is itself the `IDisposable`). All argument validation is the `Timer`
   constructor's own.
+- `TaskWait` / `TaskWaitAny` / `TaskWaitAll` convert the `TimeSpan` timeout to whole
+  milliseconds (via the shared `WaitTimeout` helper) and delegate to `Task.Wait` /
+  `Task.WaitAny` / `Task.WaitAll`. `TaskWait` null-checks `task` first; the array
+  methods leave null/element validation to the BCL.
 
 ### `MockClock`
 
@@ -197,6 +204,43 @@ up** one-per-interval rather than coalesced; and an exception thrown by the call
 **propagates** to the `AdvanceBy`/`AdvanceTo` caller (a real timer's thread-pool
 callback exception would crash the process), just as user cancellation callbacks
 surface through `CancelAfter`.
+
+## How `MockClock.TaskWait` / `TaskWaitAny` / `TaskWaitAll` work
+
+These methods block the calling thread (like `Sleep`) but measure the timeout on
+the managed time scale. The key idea is to **encode the managed-time timeout as a
+`Task`** by reusing the existing `MockClock.TaskDelay`: that task completes only
+when the clock is advanced past the deadline, never completes for an infinite
+timeout, and is already completed for a zero timeout. The wait itself is then a
+real `Task.WaitAny` over the user task(s) plus the timeout task:
+
+1. The timeout is validated exactly as `Task.Wait` validates it (whole milliseconds
+   in `[-1, int.MaxValue]`, via the shared `WaitTimeout` helper) before scheduling.
+2. A per-call `CancellationTokenSource` drives the timeout `TaskDelay`. After the
+   wait settles, a `finally` cancels it so the abandoned `ScheduledAction` is
+   dropped promptly rather than lingering on `Changed`; the cancelled timeout task
+   is never observed and raises no `UnobservedTaskException`.
+3. `Task.WaitAny(…, Timeout.Infinite, cancellationToken)` blocks until a task
+   settles or the token cancels. `Timeout.Infinite` is used because the timing
+   already lives in the timeout task (and the `(Task[], CancellationToken)` overload
+   does not exist on `netstandard2.0`). `WaitAny`'s in-order first pass means a
+   completed user task wins over an already-elapsed timeout, matching `Task.Wait`.
+4. `TaskWait` first short-circuits an already-completed task (mirroring `Task.Wait`'s
+   own fast path, where a successfully-completed task ignores the token); otherwise it
+   returns `true` (re-throwing a faulted/canceled task as an `AggregateException` via a
+   trailing `task.Wait()`) or `false` on timeout.
+   `TaskWaitAny` appends the timeout as a sentinel task and maps its index to `-1`;
+   it returns a faulted task's index without throwing. `TaskWaitAll` waits on
+   `Task.WhenAll(tasks)` so it completes only once every task has, re-throwing the
+   aggregated faults via the same trailing `.Wait()`.
+
+Because `TaskDelay` completes its task with `RunContinuationsAsynchronously`,
+completing the timeout from inside `AdvanceBy`/`AdvanceTo` does not run the waiter's
+continuations inline on the advancing thread — the advance returns promptly and the
+blocked thread wakes on the thread pool. (One parity caveat: a multi-faulted
+`TaskWaitAll` aggregates through `Task.WhenAll`, so the order of the resulting
+`AggregateException.InnerExceptions` may differ from `Task.WaitAll`; only the
+throw-vs-no-throw behaviour and the set of wrapped exceptions are guaranteed.)
 
 ## Target frameworks and build layout
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -53,6 +53,12 @@ The operating-system clock:
   `source.CancelAfter(timeout)`.
 - `SystemClock.Instance.StartTimer(state, dueTime, interval, callback)` creates a
   `System.Threading.Timer(callback, state, dueTime, interval)`.
+- `SystemClock.Instance.TaskWait(task, timeout, cancellationToken)` delegates to
+  `task.Wait(...)`.
+- `SystemClock.Instance.TaskWaitAny(tasks, timeout, cancellationToken)` delegates to
+  `Task.WaitAny(...)`.
+- `SystemClock.Instance.TaskWaitAll(tasks, timeout, cancellationToken)` delegates to
+  `Task.WaitAll(...)`.
 
 Use it in production; use `MockClock` in tests.
 
@@ -265,3 +271,48 @@ ten-second step or in five one-second steps both yield five ticks. (This differs
 from a real `Timer`, which runs its callback on a thread-pool thread and may
 coalesce missed ticks. An exception thrown by the callback likewise propagates to
 the `AdvanceBy`/`AdvanceTo` caller rather than being swallowed.)
+
+### `TaskWait` / `TaskWaitAny` / `TaskWaitAll` semantics
+
+`MockClock.TaskWait`, `TaskWaitAny`, and `TaskWaitAll` are the
+time-advancement-driven counterparts of `Task.Wait`, `Task.WaitAny`, and
+`Task.WaitAll`. They block the calling thread (just like `Sleep`) until either the
+awaited task(s) settle or the `timeout` elapses — but the `timeout` is measured on
+the **managed time scale**, so it elapses only when the clock is advanced to
+`UtcNow + timeout` (via `AdvanceBy`/`AdvanceTo`), typically from another thread.
+
+The return and exception contract matches the BCL methods:
+
+| Method                  | Returns                                                | On timeout |
+| ----------------------- | ------------------------------------------------------ | ---------- |
+| `TaskWait(task, …)`     | `true` once `task` completes within the timeout        | `false`    |
+| `TaskWaitAny(tasks, …)` | the index of the first task to complete                | `-1`       |
+| `TaskWaitAll(tasks, …)` | `true` once every task completes within the timeout    | `false`    |
+
+- `timeout` is truncated to whole milliseconds and must be between `-1`
+  (`Timeout.InfiniteTimeSpan`, an indefinite wait) and `int.MaxValue` inclusive;
+  otherwise `ArgumentOutOfRangeException` is thrown. `TimeSpan.Zero` returns
+  immediately after testing the current state.
+- Cancelling `cancellationToken` while a wait is blocked throws
+  `OperationCanceledException`.
+- A faulted or canceled task is re-thrown as an `AggregateException` by `TaskWait`
+  and `TaskWaitAll`. `TaskWaitAny` never throws for a faulted task — it just returns
+  the task's index.
+- A `null` `task`/`tasks` argument throws `ArgumentNullException`; a `null` element
+  inside `tasks` throws `ArgumentException`.
+
+```csharp
+var clock = new MockClock();
+var gate = new TaskCompletionSource<bool>();
+
+// On a worker thread, wait up to 30 (managed) seconds for the task.
+bool completed = false;
+var waiter = new Thread(() => completed = clock.TaskWait(gate.Task, TimeSpan.FromSeconds(30)));
+waiter.Start();
+
+// Advancing past the timeout makes the wait return false.
+clock.AdvanceBy(TimeSpan.FromSeconds(30));
+waiter.Join();
+
+Assert.False(completed); // the gate never completed within the managed timeout
+```

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
 		<!-- Pre-1.0 exception active: while MajorVersion is 0, breaking changes do NOT bump
 		     Major (see CONTRIBUTING.md "Pre-1.0 versioning"). Remove that note when raising to 1. -->
 		<MajorVersion>0</MajorVersion>
-		<MinorVersion>5</MinorVersion>
+		<MinorVersion>6</MinorVersion>
 		<Revision>0</Revision>
 		<Version>$(MajorVersion).$(MinorVersion).$(Revision)</Version>
 		<AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>

--- a/src/WindyCliffs.Clock.Tests/MockClockTests.TaskWait.cs
+++ b/src/WindyCliffs.Clock.Tests/MockClockTests.TaskWait.cs
@@ -1,0 +1,510 @@
+namespace WindyCliffs.Clock.Tests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public partial class MockClockTests
+    {
+        private static readonly TimeSpan TestWaitTimeout = TimeSpan.FromSeconds(10);
+
+        // Runs `wait` (handed the test cancellation token) on a worker thread, confirms it is genuinely
+        // blocked, then performs `releaseWhileBlocked` (advance the clock, complete a task, cancel a
+        // token, ...) and reports what the wait produced. Mirrors the Sleep_PositiveTimeout pattern.
+        private static (bool Finished, T Result, Exception? Error) RunBlockedWait<T>(
+            Func<CancellationToken, T> wait,
+            Action releaseWhileBlocked,
+            CancellationToken testToken)
+        {
+            using var started = new ManualResetEventSlim(false);
+            using var finished = new ManualResetEventSlim(false);
+
+            T result = default!;
+            Exception? error = null;
+
+            var thread = new Thread(_ =>
+            {
+                started.Set();
+
+                try
+                {
+                    result = wait(testToken);
+                }
+                catch (Exception ex)
+                {
+                    error = ex;
+                }
+                finally
+                {
+                    finished.Set();
+                }
+            });
+
+            thread.Start();
+
+            Assert.True(started.Wait(TimeSpan.FromSeconds(5), testToken), "Worker never started.");
+
+            // A generous margin so the worker is firmly inside the blocking wait (and has scheduled its
+            // managed-time timeout) before we release it.
+            Assert.False(finished.Wait(TimeSpan.FromSeconds(1), testToken), "Wait returned before it was released.");
+
+            releaseWhileBlocked();
+
+            bool finishedInTime = finished.Wait(TimeSpan.FromSeconds(5), testToken);
+            thread.Join(TimeSpan.FromSeconds(5));
+
+            return (finishedInTime, result, error);
+        }
+
+        private static Task Faulted() => Task.FromException(new InvalidOperationException());
+
+        // ---- TaskWait ----
+
+        [Fact]
+        public void TaskWait_NullTask()
+        {
+            var clock = new MockClock();
+
+            Assert.Throws<ArgumentNullException>(
+                () => clock.TaskWait(null!, TestWaitTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWait_NegativeTimeout()
+        {
+            var clock = new MockClock();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => clock.TaskWait(Task.CompletedTask, TimeSpan.FromSeconds(-2), TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWait_TimeoutTooLarge()
+        {
+            var clock = new MockClock();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => clock.TaskWait(Task.CompletedTask, TimeSpan.FromDays(30), TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWait_CompletedTask_ReturnsTrue()
+        {
+            var clock = new MockClock();
+
+            Assert.True(clock.TaskWait(Task.CompletedTask, TestWaitTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWait_ZeroTimeout_IncompleteTask_ReturnsFalse()
+        {
+            var clock = new MockClock();
+            var pending = new TaskCompletionSource<bool>();
+
+            Assert.False(clock.TaskWait(pending.Task, TimeSpan.Zero, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWait_ZeroTimeout_CompletedTask_ReturnsTrue()
+        {
+            var clock = new MockClock();
+
+            Assert.True(clock.TaskWait(Task.CompletedTask, TimeSpan.Zero, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWait_FaultedTask_ThrowsAggregateException()
+        {
+            var clock = new MockClock();
+
+            AggregateException error = Assert.Throws<AggregateException>(
+                () => clock.TaskWait(Faulted(), TestWaitTimeout, TestContext.Current.CancellationToken));
+            Assert.IsType<InvalidOperationException>(error.InnerException);
+        }
+
+        [Fact]
+        public void TaskWait_AlreadyCancelledTokenButCompletedTask_ReturnsTrue()
+        {
+            var clock = new MockClock();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // A completed task wins over the cancelled token, matching Task.Wait — no exception.
+            Assert.True(clock.TaskWait(Task.CompletedTask, TestWaitTimeout, cts.Token));
+        }
+
+        [Fact]
+        public void TaskWait_TimesOutWhenClockAdvances_ReturnsFalse()
+        {
+            var clock = new MockClock();
+            var pending = new TaskCompletionSource<bool>();
+
+            var outcome = RunBlockedWait(
+                token => clock.TaskWait(pending.Task, TestWaitTimeout, token),
+                () => clock.AdvanceBy(TestWaitTimeout),
+                TestContext.Current.CancellationToken);
+
+            Assert.True(outcome.Finished, "Wait never returned after the clock advanced past the timeout.");
+            Assert.Null(outcome.Error);
+            Assert.False(outcome.Result);
+        }
+
+        [Fact]
+        public void TaskWait_TaskCompletesWhileWaiting_ReturnsTrue()
+        {
+            var clock = new MockClock();
+            var pending = new TaskCompletionSource<bool>();
+
+            var outcome = RunBlockedWait(
+                token => clock.TaskWait(pending.Task, TestWaitTimeout, token),
+                () => pending.SetResult(true),
+                TestContext.Current.CancellationToken);
+
+            Assert.True(outcome.Finished, "Wait never returned after the task completed.");
+            Assert.Null(outcome.Error);
+            Assert.True(outcome.Result);
+        }
+
+        [Fact]
+        public void TaskWait_CancelledWhileWaiting_ThrowsOperationCanceled()
+        {
+            var clock = new MockClock();
+            var pending = new TaskCompletionSource<bool>();
+            using var cts = new CancellationTokenSource();
+
+            var outcome = RunBlockedWait(
+                _ => clock.TaskWait(pending.Task, TestWaitTimeout, cts.Token),
+                () => cts.Cancel(),
+                TestContext.Current.CancellationToken);
+
+            Assert.True(outcome.Finished, "Wait never returned after cancellation.");
+            Assert.IsAssignableFrom<OperationCanceledException>(outcome.Error);
+        }
+
+        [Fact]
+        public void TaskWait_InfiniteTimeout_DoesNotTimeOutWhenClockAdvances()
+        {
+            var clock = new MockClock();
+            var pending = new TaskCompletionSource<bool>();
+            CancellationToken testToken = TestContext.Current.CancellationToken;
+            using var started = new ManualResetEventSlim(false);
+            using var finished = new ManualResetEventSlim(false);
+
+            var thread = new Thread(_ =>
+            {
+                started.Set();
+                clock.TaskWait(pending.Task, Timeout.InfiniteTimeSpan, testToken);
+                finished.Set();
+            });
+
+            thread.Start();
+            Assert.True(started.Wait(TimeSpan.FromSeconds(5), testToken), "Worker never started.");
+            Assert.False(finished.Wait(TimeSpan.FromSeconds(1), testToken), "Wait returned prematurely.");
+
+            clock.AdvanceBy(TimeSpan.FromHours(1));
+
+            Assert.False(
+                finished.Wait(TimeSpan.FromMilliseconds(500), testToken),
+                "Infinite wait returned when the clock was advanced.");
+
+            // Release the worker so the test does not leak a blocked thread.
+            pending.SetResult(true);
+            Assert.True(finished.Wait(TimeSpan.FromSeconds(5), testToken), "Worker never finished.");
+            thread.Join(TimeSpan.FromSeconds(5));
+        }
+
+        // ---- TaskWaitAny ----
+
+        [Fact]
+        public void TaskWaitAny_NullTasks()
+        {
+            var clock = new MockClock();
+
+            Assert.Throws<ArgumentNullException>(
+                () => clock.TaskWaitAny(null!, TestWaitTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAny_NullElement()
+        {
+            var clock = new MockClock();
+
+            Assert.Throws<ArgumentException>(
+                () => clock.TaskWaitAny(new Task[] { null! }, TestWaitTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAny_NegativeTimeout()
+        {
+            var clock = new MockClock();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => clock.TaskWaitAny(new[] { Task.CompletedTask }, TimeSpan.FromSeconds(-2), TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAny_EmptyArray_ReturnsMinusOne()
+        {
+            var clock = new MockClock();
+
+            Assert.Equal(-1, clock.TaskWaitAny(Array.Empty<Task>(), TestWaitTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAny_CompletedTask_ReturnsIndex()
+        {
+            var clock = new MockClock();
+            var pending = new TaskCompletionSource<bool>();
+
+            Assert.Equal(1, clock.TaskWaitAny(new[] { pending.Task, Task.CompletedTask }, TestWaitTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAny_MultipleCompleted_ReturnsLowestIndex()
+        {
+            var clock = new MockClock();
+
+            Assert.Equal(0, clock.TaskWaitAny(new[] { Task.CompletedTask, Task.CompletedTask }, TestWaitTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAny_FaultedTask_ReturnsIndexWithoutThrowing()
+        {
+            var clock = new MockClock();
+
+            Assert.Equal(0, clock.TaskWaitAny(new[] { Faulted() }, TestWaitTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAny_TimesOutWhenClockAdvances_ReturnsMinusOne()
+        {
+            var clock = new MockClock();
+            var pending = new TaskCompletionSource<bool>();
+
+            var outcome = RunBlockedWait(
+                token => clock.TaskWaitAny(new[] { pending.Task }, TestWaitTimeout, token),
+                () => clock.AdvanceBy(TestWaitTimeout),
+                TestContext.Current.CancellationToken);
+
+            Assert.True(outcome.Finished, "Wait never returned after the clock advanced past the timeout.");
+            Assert.Null(outcome.Error);
+            Assert.Equal(-1, outcome.Result);
+        }
+
+        [Fact]
+        public void TaskWaitAny_TaskCompletesWhileWaiting_ReturnsIndex()
+        {
+            var clock = new MockClock();
+            var first = new TaskCompletionSource<bool>();
+            var second = new TaskCompletionSource<bool>();
+
+            var outcome = RunBlockedWait(
+                token => clock.TaskWaitAny(new[] { first.Task, second.Task }, TestWaitTimeout, token),
+                () => second.SetResult(true),
+                TestContext.Current.CancellationToken);
+
+            Assert.True(outcome.Finished, "Wait never returned after a task completed.");
+            Assert.Null(outcome.Error);
+            Assert.Equal(1, outcome.Result);
+        }
+
+        [Fact]
+        public void TaskWaitAny_CancelledWhileWaiting_ThrowsOperationCanceled()
+        {
+            var clock = new MockClock();
+            var pending = new TaskCompletionSource<bool>();
+            using var cts = new CancellationTokenSource();
+
+            var outcome = RunBlockedWait(
+                _ => clock.TaskWaitAny(new[] { pending.Task }, TestWaitTimeout, cts.Token),
+                () => cts.Cancel(),
+                TestContext.Current.CancellationToken);
+
+            Assert.True(outcome.Finished, "Wait never returned after cancellation.");
+            Assert.IsAssignableFrom<OperationCanceledException>(outcome.Error);
+        }
+
+        [Fact]
+        public void TaskWaitAny_AlreadyCancelledToken_Throws()
+        {
+            var clock = new MockClock();
+            var pending = new TaskCompletionSource<bool>();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // Task.WaitAny observes an already-cancelled token before any task, so even an incomplete
+            // wait throws immediately rather than blocking.
+            Assert.Throws<OperationCanceledException>(
+                () => clock.TaskWaitAny(new[] { pending.Task }, TestWaitTimeout, cts.Token));
+        }
+
+        // ---- TaskWaitAll ----
+
+        [Fact]
+        public void TaskWaitAll_NullTasks()
+        {
+            var clock = new MockClock();
+
+            Assert.Throws<ArgumentNullException>(
+                () => clock.TaskWaitAll(null!, TestWaitTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAll_NullElement()
+        {
+            var clock = new MockClock();
+
+            Assert.Throws<ArgumentException>(
+                () => clock.TaskWaitAll(new Task[] { null! }, TestWaitTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAll_NegativeTimeout()
+        {
+            var clock = new MockClock();
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => clock.TaskWaitAll(new[] { Task.CompletedTask }, TimeSpan.FromSeconds(-2), TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAll_EmptyArray_ReturnsTrue()
+        {
+            var clock = new MockClock();
+
+            Assert.True(clock.TaskWaitAll(Array.Empty<Task>(), TestWaitTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAll_AllCompleted_ReturnsTrue()
+        {
+            var clock = new MockClock();
+
+            Assert.True(clock.TaskWaitAll(new[] { Task.CompletedTask, Task.CompletedTask }, TestWaitTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAll_FaultedTask_ThrowsAggregateException()
+        {
+            var clock = new MockClock();
+
+            AggregateException error = Assert.Throws<AggregateException>(
+                () => clock.TaskWaitAll(new[] { Task.CompletedTask, Faulted() }, TestWaitTimeout, TestContext.Current.CancellationToken));
+            Assert.IsType<InvalidOperationException>(error.InnerException);
+        }
+
+        [Fact]
+        public void TaskWaitAll_TimesOutWhenClockAdvances_ReturnsFalse()
+        {
+            var clock = new MockClock();
+            var pending = new TaskCompletionSource<bool>();
+
+            var outcome = RunBlockedWait(
+                token => clock.TaskWaitAll(new[] { Task.CompletedTask, pending.Task }, TestWaitTimeout, token),
+                () => clock.AdvanceBy(TestWaitTimeout),
+                TestContext.Current.CancellationToken);
+
+            Assert.True(outcome.Finished, "Wait never returned after the clock advanced past the timeout.");
+            Assert.Null(outcome.Error);
+            Assert.False(outcome.Result);
+        }
+
+        [Fact]
+        public void TaskWaitAll_TasksCompleteWhileWaiting_ReturnsTrue()
+        {
+            var clock = new MockClock();
+            var first = new TaskCompletionSource<bool>();
+            var second = new TaskCompletionSource<bool>();
+
+            var outcome = RunBlockedWait(
+                token => clock.TaskWaitAll(new[] { first.Task, second.Task }, TestWaitTimeout, token),
+                () =>
+                {
+                    first.SetResult(true);
+                    second.SetResult(true);
+                },
+                TestContext.Current.CancellationToken);
+
+            Assert.True(outcome.Finished, "Wait never returned after the tasks completed.");
+            Assert.Null(outcome.Error);
+            Assert.True(outcome.Result);
+        }
+
+        [Fact]
+        public void TaskWaitAll_CancelledWhileWaiting_ThrowsOperationCanceled()
+        {
+            var clock = new MockClock();
+            var pending = new TaskCompletionSource<bool>();
+            using var cts = new CancellationTokenSource();
+
+            var outcome = RunBlockedWait(
+                _ => clock.TaskWaitAll(new[] { Task.CompletedTask, pending.Task }, TestWaitTimeout, cts.Token),
+                () => cts.Cancel(),
+                TestContext.Current.CancellationToken);
+
+            Assert.True(outcome.Finished, "Wait never returned after cancellation.");
+            Assert.IsAssignableFrom<OperationCanceledException>(outcome.Error);
+        }
+
+        [Fact]
+        public void TaskWaitAll_AlreadyCancelledTokenWithCompletedTasks_Throws()
+        {
+            var clock = new MockClock();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // Unlike TaskWait, Task.WaitAll throws for an already-cancelled token even when every task
+            // has completed; the managed implementation must match that on every target framework.
+            Assert.Throws<OperationCanceledException>(
+                () => clock.TaskWaitAll(new[] { Task.CompletedTask, Task.CompletedTask }, TestWaitTimeout, cts.Token));
+        }
+
+        // ---- Parity with SystemClock for already-settled inputs ----
+
+        [Fact]
+        public void Parity_TaskWait_CompletedTask()
+        {
+            var clock = new MockClock();
+            CancellationToken token = TestContext.Current.CancellationToken;
+
+            Assert.Equal(
+                SystemClock.Instance.TaskWait(Task.CompletedTask, TestWaitTimeout, token),
+                clock.TaskWait(Task.CompletedTask, TestWaitTimeout, token));
+        }
+
+        [Fact]
+        public void Parity_TaskWait_FaultedTask_BothThrowAggregate()
+        {
+            var clock = new MockClock();
+            CancellationToken token = TestContext.Current.CancellationToken;
+
+            Assert.Throws<AggregateException>(() => SystemClock.Instance.TaskWait(Faulted(), TestWaitTimeout, token));
+            Assert.Throws<AggregateException>(() => clock.TaskWait(Faulted(), TestWaitTimeout, token));
+        }
+
+        [Fact]
+        public void Parity_TaskWaitAny_MultipleCompleted_LowestIndex()
+        {
+            var clock = new MockClock();
+            CancellationToken token = TestContext.Current.CancellationToken;
+            var system = new[] { Task.CompletedTask, Task.CompletedTask };
+            var mock = new[] { Task.CompletedTask, Task.CompletedTask };
+
+            Assert.Equal(
+                SystemClock.Instance.TaskWaitAny(system, TestWaitTimeout, token),
+                clock.TaskWaitAny(mock, TestWaitTimeout, token));
+        }
+
+        [Fact]
+        public void Parity_TaskWaitAll_EmptyArray()
+        {
+            var clock = new MockClock();
+            CancellationToken token = TestContext.Current.CancellationToken;
+
+            Assert.Equal(
+                SystemClock.Instance.TaskWaitAll(Array.Empty<Task>(), TestWaitTimeout, token),
+                clock.TaskWaitAll(Array.Empty<Task>(), TestWaitTimeout, token));
+        }
+    }
+}

--- a/src/WindyCliffs.Clock.Tests/SystemClockTests.cs
+++ b/src/WindyCliffs.Clock.Tests/SystemClockTests.cs
@@ -280,5 +280,158 @@ namespace WindyCliffs.Clock.Tests
 
             Assert.False(fired.Wait(TimeSpan.FromMilliseconds(200), TestContext.Current.CancellationToken), "Timer fired despite an infinite due time.");
         }
+
+        // A short, fixed wall-clock budget for the genuine-timeout tests below, large enough to be
+        // reliable on a loaded CI machine without slowing the suite (cf. CancelAfter_CancelsAfterDelay).
+        private static readonly TimeSpan ShortTimeout = TimeSpan.FromMilliseconds(50);
+
+        [Fact]
+        public void TaskWait_NullTask()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => SystemClock.Instance.TaskWait(null!, ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWait_NegativeTimeout()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => SystemClock.Instance.TaskWait(Task.CompletedTask, TimeSpan.FromSeconds(-2), TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWait_TimeoutTooLarge()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => SystemClock.Instance.TaskWait(Task.CompletedTask, TimeSpan.FromDays(30), TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWait_CompletedTask_ReturnsTrue()
+        {
+            Assert.True(SystemClock.Instance.TaskWait(Task.CompletedTask, ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWait_TimesOut_ReturnsFalse()
+        {
+            var pending = new TaskCompletionSource<bool>();
+
+            Assert.False(SystemClock.Instance.TaskWait(pending.Task, ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWait_AlreadyCancelledToken()
+        {
+            var pending = new TaskCompletionSource<bool>();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.Throws<OperationCanceledException>(
+                () => SystemClock.Instance.TaskWait(pending.Task, Timeout.InfiniteTimeSpan, cts.Token));
+        }
+
+        [Fact]
+        public void TaskWait_FaultedTask_ThrowsAggregateException()
+        {
+            Task faulted = Task.FromException(new InvalidOperationException());
+
+            AggregateException error = Assert.Throws<AggregateException>(
+                () => SystemClock.Instance.TaskWait(faulted, ShortTimeout, TestContext.Current.CancellationToken));
+            Assert.IsType<InvalidOperationException>(error.InnerException);
+        }
+
+        [Fact]
+        public void TaskWaitAny_NullTasks()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => SystemClock.Instance.TaskWaitAny(null!, ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAny_NullElement()
+        {
+            Assert.Throws<ArgumentException>(
+                () => SystemClock.Instance.TaskWaitAny(new Task[] { null! }, ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAny_EmptyArray_ReturnsMinusOne()
+        {
+            Assert.Equal(-1, SystemClock.Instance.TaskWaitAny(Array.Empty<Task>(), ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAny_CompletedTask_ReturnsIndex()
+        {
+            var pending = new TaskCompletionSource<bool>();
+            var tasks = new[] { pending.Task, Task.CompletedTask };
+
+            Assert.Equal(1, SystemClock.Instance.TaskWaitAny(tasks, ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAny_TimesOut_ReturnsMinusOne()
+        {
+            var pending = new TaskCompletionSource<bool>();
+
+            Assert.Equal(-1, SystemClock.Instance.TaskWaitAny(new[] { pending.Task }, ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAny_FaultedTask_ReturnsIndexWithoutThrowing()
+        {
+            Task faulted = Task.FromException(new InvalidOperationException());
+
+            Assert.Equal(0, SystemClock.Instance.TaskWaitAny(new[] { faulted }, ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAll_NullTasks()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => SystemClock.Instance.TaskWaitAll(null!, ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAll_NullElement()
+        {
+            Assert.Throws<ArgumentException>(
+                () => SystemClock.Instance.TaskWaitAll(new Task[] { null! }, ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAll_EmptyArray_ReturnsTrue()
+        {
+            Assert.True(SystemClock.Instance.TaskWaitAll(Array.Empty<Task>(), ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAll_AllCompleted_ReturnsTrue()
+        {
+            var tasks = new[] { Task.CompletedTask, Task.CompletedTask };
+
+            Assert.True(SystemClock.Instance.TaskWaitAll(tasks, ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAll_TimesOut_ReturnsFalse()
+        {
+            var pending = new TaskCompletionSource<bool>();
+            var tasks = new[] { Task.CompletedTask, pending.Task };
+
+            Assert.False(SystemClock.Instance.TaskWaitAll(tasks, ShortTimeout, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public void TaskWaitAll_FaultedTask_ThrowsAggregateException()
+        {
+            Task faulted = Task.FromException(new InvalidOperationException());
+            var tasks = new[] { Task.CompletedTask, faulted };
+
+            AggregateException error = Assert.Throws<AggregateException>(
+                () => SystemClock.Instance.TaskWaitAll(tasks, ShortTimeout, TestContext.Current.CancellationToken));
+            Assert.IsType<InvalidOperationException>(error.InnerException);
+        }
     }
 }

--- a/src/WindyCliffs.Clock/IClock.cs
+++ b/src/WindyCliffs.Clock/IClock.cs
@@ -139,5 +139,135 @@
         /// <paramref name="interval"/> is less than <c>-1</c> or greater than <c>4294967294</c>.
         /// </exception>
         IDisposable StartTimer(object? state, TimeSpan dueTime, TimeSpan interval, TimerCallback callback);
+
+        /// <summary>
+        /// Blocks the calling thread until <paramref name="task"/> completes, the
+        /// <paramref name="timeout"/> elapses, or <paramref name="cancellationToken"/> is cancelled.
+        /// Replacement for <see cref="Task.Wait(TimeSpan)"/> (with an added cancellation token).
+        /// </summary>
+        /// <param name="task">The task to wait on.</param>
+        /// <param name="timeout">
+        /// The amount of time to wait. <see cref="TimeSpan.Zero"/> tests the task's state and returns
+        /// immediately; <see cref="Timeout.InfiniteTimeSpan"/> waits indefinitely. The value is
+        /// truncated to whole milliseconds and must be between <c>-1</c>
+        /// (<see cref="Timeout.InfiniteTimeSpan"/>) and <see cref="int.MaxValue"/> inclusive.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A token to observe while waiting. Cancelling it transitions the wait to throwing an
+        /// <see cref="OperationCanceledException"/>.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="task"/> completed within
+        /// <paramref name="timeout"/>; otherwise <see langword="false"/>.
+        /// </returns>
+        /// <remarks>
+        /// With <see cref="MockClock"/> the <paramref name="timeout"/> is measured on the managed time
+        /// scale, so it only elapses when the clock is advanced (via <see cref="MockClock.AdvanceBy(TimeSpan)"/>
+        /// or <see cref="MockClock.AdvanceTo(DateTimeOffset)"/>); the wait itself still blocks the
+        /// calling thread, exactly as <see cref="Sleep(TimeSpan)"/> does.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// When <paramref name="task"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// When the whole-millisecond value of <paramref name="timeout"/> is less than <c>-1</c> or
+        /// greater than <see cref="int.MaxValue"/>.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">
+        /// When <paramref name="cancellationToken"/> is cancelled while waiting. As with
+        /// <see cref="Task.Wait(TimeSpan)"/>, a <paramref name="task"/> that has already run to
+        /// completion (or faulted) is reported without observing the token, so an already-cancelled
+        /// token does not suppress such a result.
+        /// </exception>
+        /// <exception cref="AggregateException">
+        /// When <paramref name="task"/> completes in the faulted or canceled state; the exception
+        /// wraps the task's exception(s).
+        /// </exception>
+        bool TaskWait(Task task, TimeSpan timeout, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Blocks the calling thread until any of the <paramref name="tasks"/> completes, the
+        /// <paramref name="timeout"/> elapses, or <paramref name="cancellationToken"/> is cancelled.
+        /// Replacement for <see cref="Task.WaitAny(Task[], int, CancellationToken)"/>.
+        /// </summary>
+        /// <param name="tasks">The tasks to wait on.</param>
+        /// <param name="timeout">
+        /// The amount of time to wait. <see cref="TimeSpan.Zero"/> tests the tasks' state and returns
+        /// immediately; <see cref="Timeout.InfiniteTimeSpan"/> waits indefinitely. The value is
+        /// truncated to whole milliseconds and must be between <c>-1</c>
+        /// (<see cref="Timeout.InfiniteTimeSpan"/>) and <see cref="int.MaxValue"/> inclusive.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A token to observe while waiting. Cancelling it transitions the wait to throwing an
+        /// <see cref="OperationCanceledException"/>.
+        /// </param>
+        /// <returns>
+        /// The index of the first completed task in <paramref name="tasks"/>, or <c>-1</c> if
+        /// <paramref name="timeout"/> elapsed first. Unlike <see cref="TaskWait"/> this does not throw
+        /// when a task completes in the faulted or canceled state; it simply returns that task's index.
+        /// </returns>
+        /// <remarks>
+        /// With <see cref="MockClock"/> the <paramref name="timeout"/> is measured on the managed time
+        /// scale, so it only elapses when the clock is advanced; the wait itself still blocks the
+        /// calling thread.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// When <paramref name="tasks"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// When <paramref name="tasks"/> contains a <see langword="null"/> element.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// When the whole-millisecond value of <paramref name="timeout"/> is less than <c>-1</c> or
+        /// greater than <see cref="int.MaxValue"/>.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">
+        /// When <paramref name="cancellationToken"/> is cancelled while waiting.
+        /// </exception>
+        int TaskWaitAny(Task[] tasks, TimeSpan timeout, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Blocks the calling thread until all of the <paramref name="tasks"/> complete, the
+        /// <paramref name="timeout"/> elapses, or <paramref name="cancellationToken"/> is cancelled.
+        /// Replacement for <see cref="Task.WaitAll(Task[], int, CancellationToken)"/>.
+        /// </summary>
+        /// <param name="tasks">The tasks to wait on.</param>
+        /// <param name="timeout">
+        /// The amount of time to wait. <see cref="TimeSpan.Zero"/> tests the tasks' state and returns
+        /// immediately; <see cref="Timeout.InfiniteTimeSpan"/> waits indefinitely. The value is
+        /// truncated to whole milliseconds and must be between <c>-1</c>
+        /// (<see cref="Timeout.InfiniteTimeSpan"/>) and <see cref="int.MaxValue"/> inclusive.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A token to observe while waiting. Cancelling it transitions the wait to throwing an
+        /// <see cref="OperationCanceledException"/>.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if every task in <paramref name="tasks"/> completed within
+        /// <paramref name="timeout"/>; otherwise <see langword="false"/>.
+        /// </returns>
+        /// <remarks>
+        /// With <see cref="MockClock"/> the <paramref name="timeout"/> is measured on the managed time
+        /// scale, so it only elapses when the clock is advanced; the wait itself still blocks the
+        /// calling thread.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// When <paramref name="tasks"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// When <paramref name="tasks"/> contains a <see langword="null"/> element.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// When the whole-millisecond value of <paramref name="timeout"/> is less than <c>-1</c> or
+        /// greater than <see cref="int.MaxValue"/>.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">
+        /// When <paramref name="cancellationToken"/> is cancelled while waiting.
+        /// </exception>
+        /// <exception cref="AggregateException">
+        /// When one or more of the <paramref name="tasks"/> complete in the faulted or canceled state;
+        /// the exception wraps the tasks' exception(s).
+        /// </exception>
+        bool TaskWaitAll(Task[] tasks, TimeSpan timeout, CancellationToken cancellationToken = default);
     }
 }

--- a/src/WindyCliffs.Clock/MockClock.cs
+++ b/src/WindyCliffs.Clock/MockClock.cs
@@ -165,6 +165,140 @@
             // schedules itself against this clock's Changed event.
             => new MockTimer(this, state, dueTime, interval, callback);
 
+        /// <inheritdoc />
+        public bool TaskWait(Task task, TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            if (task is null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            // Validate the timeout exactly as Task.Wait does, before delegating to TaskDelay (which
+            // accepts a wider range). The converted value is unused here; MockClock passes the
+            // TimeSpan straight to TaskDelay, so this call is only for its validation side effect.
+            _ = WaitTimeout.ToMilliseconds(timeout, nameof(timeout));
+
+            // Fast path mirroring Task.Wait: an already-completed task settles without blocking, and the
+            // cancellation token only takes precedence over a task that did not run to completion — and
+            // then only over a canceled one (a faulted task surfaces its own AggregateException even
+            // under a cancelled token). task.Wait() re-throws faults/cancellation as Task.Wait does.
+            if (task.IsCompleted)
+            {
+                if (task.IsCanceled)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                task.Wait();
+                return true;
+            }
+
+            // Encode the managed-time timeout as a task: TaskDelay completes only when the clock is
+            // advanced past the deadline, never completes for an infinite timeout, and is already
+            // completed for a zero timeout.
+            using var timeoutCancellation = new CancellationTokenSource();
+            Task timeoutTask = this.TaskDelay(timeout, timeoutCancellation.Token);
+            try
+            {
+                // Block in real time on whichever task settles first. Timeout.Infinite is passed as the
+                // millisecond timeout (the timing already lives in timeoutTask); the
+                // (Task[], CancellationToken) overload is unavailable on netstandard2.0. WaitAny's
+                // first pass returns the lowest already-completed index, so a completed task wins over
+                // an already-elapsed (e.g. zero) timeout, matching Task.Wait.
+                if (Task.WaitAny(new[] { task, timeoutTask }, Timeout.Infinite, cancellationToken) == 0)
+                {
+                    // The task is complete; this returns immediately and re-throws a faulted or
+                    // canceled task as an AggregateException, exactly as Task.Wait does.
+                    task.Wait();
+                    return true;
+                }
+
+                return false;
+            }
+            finally
+            {
+                // Drop the pending ScheduledAction if the timeout did not fire. The abandoned, now
+                // canceled timeoutTask is never observed and raises no UnobservedTaskException.
+                timeoutCancellation.Cancel();
+            }
+        }
+
+        /// <inheritdoc />
+        public int TaskWaitAny(Task[] tasks, TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            if (tasks is null)
+            {
+                throw new ArgumentNullException(nameof(tasks));
+            }
+
+            _ = WaitTimeout.ToMilliseconds(timeout, nameof(timeout));
+
+            // Task.WaitAny returns -1 for an empty array without waiting (but still observes an
+            // already-cancelled token first); mirror that before scheduling.
+            if (tasks.Length == 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return -1;
+            }
+
+            using var timeoutCancellation = new CancellationTokenSource();
+
+            // Append the managed-time timeout as a sentinel task; its index means "timed out".
+            var candidates = new Task[tasks.Length + 1];
+            Array.Copy(tasks, candidates, tasks.Length);
+            candidates[tasks.Length] = this.TaskDelay(timeout, timeoutCancellation.Token);
+            try
+            {
+                // Task.WaitAny validates the null elements among the user tasks. Unlike TaskWait, a
+                // faulted or canceled task is not re-thrown here: its index is simply returned.
+                int index = Task.WaitAny(candidates, Timeout.Infinite, cancellationToken);
+                return index == tasks.Length ? -1 : index;
+            }
+            finally
+            {
+                timeoutCancellation.Cancel();
+            }
+        }
+
+        /// <inheritdoc />
+        public bool TaskWaitAll(Task[] tasks, TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            if (tasks is null)
+            {
+                throw new ArgumentNullException(nameof(tasks));
+            }
+
+            _ = WaitTimeout.ToMilliseconds(timeout, nameof(timeout));
+
+            // Mirror Task.WaitAll, which throws for an already-cancelled token regardless of task
+            // state. This must be explicit: TaskWaitAll blocks via Task.WaitAny (Task.WhenAll has no
+            // timeout overload), and Task.WaitAny's pre-completed-task first pass can otherwise win
+            // over a cancelled token on .NET Framework, diverging from SystemClock.TaskWaitAll.
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var timeoutCancellation = new CancellationTokenSource();
+
+            // Task.WhenAll validates the null elements, completes only once every task has, and
+            // aggregates all faults; an empty array yields an already-completed task.
+            Task completion = Task.WhenAll(tasks);
+            Task timeoutTask = this.TaskDelay(timeout, timeoutCancellation.Token);
+            try
+            {
+                if (Task.WaitAny(new[] { completion, timeoutTask }, Timeout.Infinite, cancellationToken) == 0)
+                {
+                    // Re-throw the aggregated faults as an AggregateException, like Task.WaitAll.
+                    completion.Wait();
+                    return true;
+                }
+
+                return false;
+            }
+            finally
+            {
+                timeoutCancellation.Cancel();
+            }
+        }
+
         /// <summary>
         /// Gets or sets the advancement step used by <see cref="AdvanceBy(TimeSpan)"/> and
         /// <see cref="AdvanceTo(DateTimeOffset)"/> methods.

--- a/src/WindyCliffs.Clock/SystemClock.cs
+++ b/src/WindyCliffs.Clock/SystemClock.cs
@@ -46,5 +46,28 @@
             // the null-callback and range validation the IClock contract specifies, and Timer itself is
             // the returned IDisposable (Dispose stops it — no Change-then-dispose dance is needed).
             => new Timer(callback, state, dueTime, interval);
+
+        /// <inheritdoc />
+        public bool TaskWait(Task task, TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            // Enforce the IClock contract's ArgumentNullException; a bare instance call on a null
+            // receiver would throw NullReferenceException instead (same reasoning as CancelAfter).
+            if (task is null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+
+            return task.Wait(WaitTimeout.ToMilliseconds(timeout, nameof(timeout)), cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public int TaskWaitAny(Task[] tasks, TimeSpan timeout, CancellationToken cancellationToken = default)
+            // Task.WaitAny performs the null-array and null-element validation the IClock contract specifies.
+            => Task.WaitAny(tasks, WaitTimeout.ToMilliseconds(timeout, nameof(timeout)), cancellationToken);
+
+        /// <inheritdoc />
+        public bool TaskWaitAll(Task[] tasks, TimeSpan timeout, CancellationToken cancellationToken = default)
+            // Task.WaitAll performs the null-array and null-element validation the IClock contract specifies.
+            => Task.WaitAll(tasks, WaitTimeout.ToMilliseconds(timeout, nameof(timeout)), cancellationToken);
     }
 }

--- a/src/WindyCliffs.Clock/WaitTimeout.cs
+++ b/src/WindyCliffs.Clock/WaitTimeout.cs
@@ -1,0 +1,35 @@
+namespace WindyCliffs.Clock
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Converts a <see cref="TimeSpan"/> wait timeout to the whole-millisecond <see cref="int"/> value
+    /// the <see cref="Task"/> wait overloads accept, validating it exactly as <see cref="Task.Wait(TimeSpan)"/>
+    /// does. Shared by <see cref="SystemClock"/> and <see cref="MockClock"/> so both clocks reject the
+    /// same out-of-range values on every target runtime.
+    /// </summary>
+    internal static class WaitTimeout
+    {
+        // The .NET wait APIs accept a timeout only in whole milliseconds and only up to int.MaxValue;
+        // -1 (Timeout.Infinite / Timeout.InfiniteTimeSpan) means "wait indefinitely".
+        internal static int ToMilliseconds(TimeSpan timeout, string paramName)
+        {
+            // Truncate to whole milliseconds, matching MockTimer's range check and the BCL's own
+            // Task.Wait(TimeSpan) conversion. -1 is valid (an infinite wait); anything more negative,
+            // or larger than int.MaxValue, is out of range.
+            long milliseconds = (long)timeout.TotalMilliseconds;
+
+            if (milliseconds < Timeout.Infinite || milliseconds > int.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(
+                    paramName,
+                    timeout,
+                    "The time-out value is negative and is not equal to Infinite, or is greater than int.MaxValue milliseconds.");
+            }
+
+            return (int)milliseconds;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds three blocking, timed, cancellable task-wait primitives to `IClock`, so code that uses `Task.Wait` / `Task.WaitAny` / `Task.WaitAll` can be driven deterministically in tests:

```csharp
bool TaskWait(Task task, TimeSpan timeout, CancellationToken cancellationToken = default);
int  TaskWaitAny(Task[] tasks, TimeSpan timeout, CancellationToken cancellationToken = default);
bool TaskWaitAll(Task[] tasks, TimeSpan timeout, CancellationToken cancellationToken = default);
```

- **`SystemClock`** delegates to the BCL `Task.Wait` / `Task.WaitAny` / `Task.WaitAll`.
- **`MockClock`** measures the timeout on the **managed time scale** — it encodes the timeout as a `TaskDelay` task and blocks on the real `Task.WaitAny` / `Task.WhenAll`, so the timeout elapses only when the clock is advanced via `AdvanceBy`/`AdvanceTo`, while the wait still blocks the calling thread (like `Sleep`).

This is a **breaking** change for third-party `IClock` implementers (three new members; default interface members aren't available on the `netstandard2.0` / C# 9 target), so it is a pre-1.0 minor bump to **0.6.0**.

## Notable changes

- New shared `WaitTimeout` helper converts and range-validates the `TimeSpan` exactly as `Task.Wait(TimeSpan)` does.
- BCL cancellation/fault parity matched precisely, verified empirically against the runtime:
  - `TaskWait` fast-paths an already-completed task, ignoring a cancelled token (except a *canceled* task, where the token wins) — mirroring `Task.Wait`.
  - `TaskWaitAll` does an explicit early token check so its `OperationCanceledException` behaviour matches `Task.WaitAll` on **every** target framework (it blocks via `Task.WaitAny` internally, whose first-pass could otherwise diverge on .NET Framework).
- Full XML docs on the new members; `USAGE.md`, `ARCHITECTURE.md`, `README.md`, and `CHANGELOG.md` updated.
- Documented parity caveat: a multi-faulted `TaskWaitAll` aggregates via `Task.WhenAll`, so the *order* of `AggregateException.InnerExceptions` may differ from `Task.WaitAll` (membership and throw/no-throw are guaranteed).

## Testing

- `dotnet build src/repo.slnx -c Release -warnaserror` — **0 warnings, 0 errors**.
- `dotnet test src/repo.slnx -c Release` — **169 passed, 0 failed** on `net48`, `net8.0`, and `net10.0`.
- New `SystemClock` and `MockClock` test matrices cover validation, timeout, completion, cancellation (including already-cancelled-token corners), faults, time-advancement, lowest-index priority, plus cross-implementation parity tests for already-settled inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)